### PR TITLE
Permit optional code block when adding a job

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,16 @@ After adding a job, it will remain active and will run every time QuickBooks Web
 
 Use the [Onscreen Reference for Intuit Software Development Kits](https://developer-static.intuit.com/qbSDK-current/Common/newOSR/index.html) (use Format: qbXML) to see request and response formats to use in your jobs. Use underscored, lowercased versions of all tags (e.g. `customer_query_rq`, not `CustomerQueryRq`).
 
+### Requests via code block ###
+
+In order to access local variables for a request, you can optionally provide a code block to QBWC.add_job. If provided, this code block can return a single qbxml request, or an array of qbxml requests. The code block is evaluated only when the job is added.
+
+If the requests method returns a non-nil value, then this value will be used to create the request and the value returned from the code block will be ignored.
+
 ### Check versions ###
 
 If you want to return server version or check client version you can override server_version_response or check_client_version methods in your controller. Check QB web connector guide for allowed responses.
-
+s
 ## Contributing to qbwc
 
 * Check out the latest master to make sure the feature hasn't been implemented or the bug hasn't been fixed yet

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ If the requests method returns a non-nil value, then this value will be used to 
 ### Check versions ###
 
 If you want to return server version or check client version you can override server_version_response or check_client_version methods in your controller. Check QB web connector guide for allowed responses.
-s
+
 ## Contributing to qbwc
 
 * Check out the latest master to make sure the feature hasn't been implemented or the bug hasn't been fixed yet

--- a/lib/qbwc.rb
+++ b/lib/qbwc.rb
@@ -60,8 +60,8 @@ module QBWC
       storage_module::Job.list_jobs
     end
 
-    def add_job(name, enabled, company, klass)
-      storage_module::Job.add_job(name, enabled, company, klass)
+    def add_job(name, enabled = true, company = nil, klass = QBWC::Worker, &block)
+      storage_module::Job.add_job(name, enabled, company, klass, &block)
     end
 
     def get_job(name)

--- a/lib/qbwc/active_record/job.rb
+++ b/lib/qbwc/active_record/job.rb
@@ -11,6 +11,7 @@ class QBWC::ActiveRecord::Job < QBWC::Job
 
   # Creates and persists a job.
   def self.add_job(name, enabled, company, worker_class)
+
     worker_class = worker_class.to_s
     ar_job = find_ar_job_with_name(name).first_or_initialize
     ar_job.company = company
@@ -18,7 +19,15 @@ class QBWC::ActiveRecord::Job < QBWC::Job
     ar_job.request_index = 0
     ar_job.worker_class = worker_class
     ar_job.save!
-    self.new(name, enabled, company, worker_class)
+
+    jb = self.new(name, enabled, company, worker_class)
+
+    if block_given?
+      rqs = yield
+      jb.requests = rqs.is_a?(Array) ? rqs : [rqs]
+    end
+
+    jb
   end
 
   def self.find_job_with_name(name)

--- a/lib/qbwc/job.rb
+++ b/lib/qbwc/job.rb
@@ -67,11 +67,15 @@ class QBWC::Job
 
   def next
     # Generate and save the requests to run when starting the job.
-    if requests.nil? || requests.empty?
+    unless @worker_requests_called
       r = worker.requests
-      r = [r] if r.is_a?(Hash)
-      self.requests = r
+      @worker_requests_called = true
+      unless r.nil?
+        r = [r] if r.is_a?(Hash)
+        self.requests = r
+      end
     end
+
     QBWC.logger.info("Requests available are '#{requests}'.")
     ri = request_index
     QBWC.logger.info("Request index is '#{ri}'.")
@@ -83,7 +87,7 @@ class QBWC::Job
 
   def reset
     self.request_index = 0
-    self.requests = []
+    #self.requests = []
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,6 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 

--- a/test/qbwc/integration/request_generation_test.rb
+++ b/test/qbwc/integration/request_generation_test.rb
@@ -145,6 +145,8 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
     assert_match /Foo.bar.\/Foo/, request.request
     simulate_response(session)
     assert_nil session.next
+
+    assert_equal [{:foo => 'bar'}], QBWC::ActiveRecord::Job::QbwcJob.first[:requests]
   end
 
   class CodeBlockOverridesRequestWorker < QBWC::Worker
@@ -163,6 +165,8 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
     assert_match /Name.#{QBWC_USERNAME}.\/Name/, request.request
     simulate_response(session)
     assert_nil session.next
+
+    assert_equal [QBWC_CUSTOMER_ADD_RQ], QBWC::ActiveRecord::Job::QbwcJob.first[:requests]
   end
 
   class SimulatedUserModel
@@ -187,6 +191,8 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
     session = QBWC::Session.new('foo', '')
     request = session.next
     assert_match /Name.#{QBWC_USERNAME}.\/Name/, request.request
+
+    assert_equal [{:name => QBWC_USERNAME}], QBWC::ActiveRecord::Job::QbwcJob.first[:requests]
   end
 
   class CodeBlockReturnsMultipleRequestsWorker < QBWC::Worker
@@ -221,6 +227,8 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
     simulate_response(session)
 
     assert_nil session.next
+
+    assert_equal [{:name => QBWC_USERNAME}, {:name => 'usr2 name'}], QBWC::ActiveRecord::Job::QbwcJob.first[:requests]
   end
 
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -127,9 +127,7 @@ end
 #-------------------------------------------
 def _authenticate_with_queued_job
   # Queue a job
-  QBWC.add_job(:customer_add_rq_job, true, COMPANY, QBWC::Worker) do
-    QBWC_CUSTOMER_ADD_RQ
-  end
+  QBWC.add_job(:customer_add_rq_job, true, COMPANY, QBWC::Worker)
 
   _authenticate
 end


### PR DESCRIPTION
The original qbwc gem supported an optional code block to QBWC.add_job that could be used to define a request. This pull request restores a mostly similar functionality, primarily for backwards compatibility. Addresses https://github.com/skryl/qbwc/issues/36

This is an early draft that passes all existing tests and appears to work for my application's use case (though still early days). I'd appreciate a second pair of eyes on it as my understanding of this gem's internals is somewhat limited.
