### PR TITLE
Permit passing optional requests when adding a job

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Use the [Onscreen Reference for Intuit Software Development Kits](https://develo
 
 You can optionally provide requests directly to QBWC.add_job. If provided, these requests can return a single qbxml request, or an array of qbxml requests.
 
-Any non-nil worker requests override those passed to add_job; if the worker requests method returns a non-nil value, then this value will be used to create the request (and the requests passed to add_job will be ignored).
+The worker requests method overrides requests passed to add_job; if the worker requests method returns a non-nil value, then this value will be used to create the request (and the requests passed to add_job will be ignored).
 
 ### Check versions ###
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ After adding a job, it will remain active and will run every time QuickBooks Web
 
 Use the [Onscreen Reference for Intuit Software Development Kits](https://developer-static.intuit.com/qbSDK-current/Common/newOSR/index.html) (use Format: qbXML) to see request and response formats to use in your jobs. Use underscored, lowercased versions of all tags (e.g. `customer_query_rq`, not `CustomerQueryRq`).
 
+### Requests passed to add_job ###
+
+You can optionally provide requests directly to QBWC.add_job. If provided, these requests can return a single qbxml request, or an array of qbxml requests.
+
+Any non-nil worker requests override those passed to add_job; if the worker requests method returns a non-nil value, then this value will be used to create the request (and the requests passed to add_job will be ignored).
+
 ### Check versions ###
 
 If you want to return server version or check client version you can override server_version_response or check_client_version methods in your controller. Check QB web connector guide for allowed responses.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A job is associated to a worker, which is an object descending from `QBWC::Worke
 
 - `requests` - defines the request(s) that QuickBooks should process - returns a `Hash` or an `Array` of `Hash`es.
 - `should_run?` - whether this job should run (e.g. you can have a job run only under certain circumstances) - returns `Boolean` and defaults to `true`.
-- `handle_response(response, job)` - defines what to do with the response from Quickbooks.
+- `handle_response(response, job, data)` - defines what to do with the response from Quickbooks.
 
 A sample worker to get a list of customers from QuickBooks:
 
@@ -62,7 +62,7 @@ class CustomerTestWorker < QBWC::Worker
 		}
 	end
 
-	def handle_response(r, job)
+	def handle_response(r, job, data)
 		# handle_response will get customers in groups of 100. When this is 0, we're done.
 		complete = r['xml_attributes']['iteratorRemainingCount'] == '0'
 
@@ -86,7 +86,7 @@ QBWC.add_job(:list_customers, false, '', CustomerTestWorker)
 After adding a job, it will remain active and will run every time QuickBooks Web Connector runs an update. If you don't want this to happen, you can have custom logic in your worker's `should_run?` or have your job disable or delete itself after completion. For example:
 
 ```ruby
-	def handle_response(r, job)
+	def handle_response(r, job, data)
 		QBWC.delete_job(job.name)
 	end
 
@@ -100,6 +100,10 @@ Use the [Onscreen Reference for Intuit Software Development Kits](https://develo
 You can optionally provide requests directly to QBWC.add_job. If provided, these requests can return a single qbxml request, or an array of qbxml requests.
 
 The worker requests method overrides requests passed to add_job; if the worker requests method returns a non-nil value, then this value will be used to create the request (and the requests passed to add_job will be ignored).
+
+### Data passed to add_job ###
+
+You can optionally provide arbitrary data directly to QBWC.add_job. If provided, this data will be passed to handle_response.
 
 ### Check versions ###
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ A job is associated to a worker, which is an object descending from `QBWC::Worke
 - `should_run?` - whether this job should run (e.g. you can have a job run only under certain circumstances) - returns `Boolean` and defaults to `true`.
 - `handle_response(response, job, data)` - defines what to do with the response from Quickbooks.
 
+All three methods are not invoked until a QuickBooks Web Connector session has been established with your web service.
+
 A sample worker to get a list of customers from QuickBooks:
 
 ```ruby
@@ -95,24 +97,29 @@ After adding a job, it will remain active and will run every time QuickBooks Web
 
 Use the [Onscreen Reference for Intuit Software Development Kits](https://developer-static.intuit.com/qbSDK-current/Common/newOSR/index.html) (use Format: qbXML) to see request and response formats to use in your jobs. Use underscored, lowercased versions of all tags (e.g. `customer_query_rq`, not `CustomerQueryRq`).
 
-### Requests passed to add_job ###
+### Referencing memory values when constructing requests ###
 
-You can optionally provide requests directly to QBWC.add_job. If provided, these requests can return a single qbxml request, or an array of qbxml requests.
+A QBWC::Worker#requests method cannot access values that are in-memory (local variables, model attributes, etc.) at the time that QBWC.add_job is called; however, in lieu of using QBWC::Worker#requests, you can optionally construct and pass requests directly to QBWC.add_job (scalar request or array of requests). These requests will be immediately persisted by QBWC.add_job (in contrast to requests constructed by QBWC::Worker#requests, which are persisted during a QuickBooks Web Connector session).
 
-The worker requests method overrides requests passed to add_job; if the worker requests method returns a non-nil value, then this value will be used to create the request (and the requests passed to add_job will be ignored).
+A QBWC::Worker#requests method overrides any requests passed to QBWC.add_job; if QBWC::Worker#requests returns a non-nil value, then this value will be sent to QuickBooks Web Connector (and any requests passed directly to QBWC.add_job will be ignored).
 
-### Data passed to add_job ###
+### Referencing memory values when handling responses ###
 
-You can optionally provide arbitrary data directly to QBWC.add_job. If provided, this data will be passed to handle_response.
+Similarly, a QBWC::Worker#handle_response method cannot access values that are in-memory at the time that QBWC.add_job is called; however, you can optionally pass arbitrary (serializable) data values to QBWC.add_job. This data will immediately be serialized and persisted by QBWC.add_job, then later deserialized and passed to QBWC::Worker#handle_response during a QuickBooks Web Connector session.
 
 ### Sessions ###
 
-You may optionally specify an initialization block that will be called when each QuickBooks Web Connector session is established:
+In certain cases, you may want to perform some initialization prior to each QuickBooks Web Connector session (a QuickBooks Web Connector session is established when you manually run (update) an application's web service in QuickBooks Web Connector, or when QuickBooks Web Connector automatically executes a scheduled update). For this purpose, you may optionally provide an initialization block that will be invoked once when each QuickBooks Web Connector session is established, and prior to executing any queued jobs.
+
+You assign this initialization block prior to any QuickBooks Web Connector session being established, outside of any QBWC::Worker classes. For example:
 
 ```ruby
+        require 'qbwc'
 	QBWC.set_session_initializer() do
           puts "New QuickBooks Web Connector session has been established"
+          @information_from_jobs = {}
         end
+        QBWC.add_job(:list_customers, false, '', CustomerTestWorker)
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,17 @@ The worker requests method overrides requests passed to add_job; if the worker r
 
 You can optionally provide arbitrary data directly to QBWC.add_job. If provided, this data will be passed to handle_response.
 
+### Sessions ###
+
+You may optionally specify an initialization block that will be called when each QuickBooks Web Connector session is established:
+
+```ruby
+	QBWC.set_session_initializer() do
+          puts "New QuickBooks Web Connector session has been established"
+        end
+
+```
+
 ### Check versions ###
 
 If you want to return server version or check client version you can override server_version_response or check_client_version methods in your controller. Check QB web connector guide for allowed responses.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A job is associated to a worker, which is an object descending from `QBWC::Worke
 
 - `requests` - defines the request(s) that QuickBooks should process - returns a `Hash` or an `Array` of `Hash`es.
 - `should_run?` - whether this job should run (e.g. you can have a job run only under certain circumstances) - returns `Boolean` and defaults to `true`.
-- `handle_response(response)` - defines what to do with the response from Quickbooks.
+- `handle_response(response, job)` - defines what to do with the response from Quickbooks.
 
 A sample worker to get a list of customers from QuickBooks:
 
@@ -62,7 +62,7 @@ class CustomerTestWorker < QBWC::Worker
 		}
 	end
 
-	def handle_response(r)
+	def handle_response(r, job)
 		# handle_response will get customers in groups of 100. When this is 0, we're done.
 		complete = r['xml_attributes']['iteratorRemainingCount'] == '0'
 
@@ -83,7 +83,15 @@ require 'qbwc'
 QBWC.add_job(:list_customers, false, '', CustomerTestWorker)
 ```
 
-After adding a job, it will remain active and will run every time QuickBooks Web Connector runs an update. If you don't want this to happen, you can have custom logic in your worker's `should_run?` or have your job disable or delete itself after completion. 
+After adding a job, it will remain active and will run every time QuickBooks Web Connector runs an update. If you don't want this to happen, you can have custom logic in your worker's `should_run?` or have your job disable or delete itself after completion. For example:
+
+```ruby
+	def handle_response(r, job)
+		QBWC.delete_job(job.name)
+	end
+
+```
+
 
 Use the [Onscreen Reference for Intuit Software Development Kits](https://developer-static.intuit.com/qbSDK-current/Common/newOSR/index.html) (use Format: qbXML) to see request and response formats to use in your jobs. Use underscored, lowercased versions of all tags (e.g. `customer_query_rq`, not `CustomerQueryRq`).
 

--- a/lib/generators/qbwc/install/templates/db/migrate/create_qbwc_jobs.rb
+++ b/lib/generators/qbwc/install/templates/db/migrate/create_qbwc_jobs.rb
@@ -7,6 +7,7 @@ class CreateQbwcJobs < ActiveRecord::Migration
       t.boolean :enabled, :null => false, :default => false
       t.integer :request_index, :null => false, :default => 0
       t.text :requests
+      t.text :data
       t.timestamps
     end
   end

--- a/lib/generators/qbwc/install/templates/db/migrate/create_qbwc_jobs.rb
+++ b/lib/generators/qbwc/install/templates/db/migrate/create_qbwc_jobs.rb
@@ -8,6 +8,7 @@ class CreateQbwcJobs < ActiveRecord::Migration
       t.integer :request_index, :null => false, :default => 0
       t.text :requests
       t.text :data
+      t.boolean :worker_requests_called
       t.timestamps
     end
   end

--- a/lib/qbwc.rb
+++ b/lib/qbwc.rb
@@ -60,8 +60,8 @@ module QBWC
       storage_module::Job.list_jobs
     end
 
-    def add_job(name, enabled, company, klass)
-      storage_module::Job.add_job(name, enabled, company, klass)
+    def add_job(name, enabled = true, company = nil, klass = QBWC::Worker, requests = nil)
+      storage_module::Job.add_job(name, enabled, company, klass, requests)
     end
 
     def get_job(name)

--- a/lib/qbwc.rb
+++ b/lib/qbwc.rb
@@ -36,6 +36,9 @@ module QBWC
   mattr_accessor :minutes_to_run
   @@minutes_to_run = 5
   
+  mattr_reader :session_initializer
+  @@session_initializer = nil
+
   mattr_reader :on_error
   @@on_error = 'stopOnError'
 
@@ -79,6 +82,11 @@ module QBWC
       storage_module::Job.sort_in_time_order(js.select {|job| job.company == company && job.pending?})
     end
     
+    def set_session_initializer(&block)
+      @@session_initializer = block
+      self
+    end
+
     def on_error=(reaction)
       raise 'Quickbooks on_error must be :stop or :continue' unless [:stop, :continue].include?(reaction)
       @@on_error = "stopOnError" if reaction == :stop

--- a/lib/qbwc.rb
+++ b/lib/qbwc.rb
@@ -60,8 +60,8 @@ module QBWC
       storage_module::Job.list_jobs
     end
 
-    def add_job(name, enabled = true, company = nil, klass = QBWC::Worker, requests = nil)
-      storage_module::Job.add_job(name, enabled, company, klass, requests)
+    def add_job(name, enabled = true, company = nil, klass = QBWC::Worker, requests = nil, data = nil)
+      storage_module::Job.add_job(name, enabled, company, klass, requests, data)
     end
 
     def get_job(name)

--- a/lib/qbwc.rb
+++ b/lib/qbwc.rb
@@ -78,7 +78,6 @@ module QBWC
     def pending_jobs(company)
       js = jobs
       QBWC.logger.info "#{js.length} jobs exist, checking for pending jobs for company '#{company}'."
-      js.each { |job| job.reset }
       storage_module::Job.sort_in_time_order(js.select {|job| job.company == company && job.pending?})
     end
     

--- a/lib/qbwc.rb
+++ b/lib/qbwc.rb
@@ -68,6 +68,10 @@ module QBWC
       storage_module::Job.find_job_with_name(name)
     end
 
+    def delete_job(name)
+      storage_module::Job.delete_job_with_name(name)
+    end
+
     def pending_jobs(company)
       js = jobs
       QBWC.logger.info "#{js.length} jobs exist, checking for pending jobs for company '#{company}'."

--- a/lib/qbwc/active_record/job.rb
+++ b/lib/qbwc/active_record/job.rb
@@ -2,15 +2,16 @@ class QBWC::ActiveRecord::Job < QBWC::Job
   class QbwcJob < ActiveRecord::Base
     validates :name, :uniqueness => true, :presence => true
     serialize :requests, Array
+    serialize :data
 
     def to_qbwc_job
-      QBWC::ActiveRecord::Job.new(name, enabled, company, worker_class, requests)
+      QBWC::ActiveRecord::Job.new(name, enabled, company, worker_class, requests, data)
     end
 
   end
 
   # Creates and persists a job.
-  def self.add_job(name, enabled, company, worker_class, requests)
+  def self.add_job(name, enabled, company, worker_class, requests, data)
 
     worker_class = worker_class.to_s
     ar_job = find_ar_job_with_name(name).first_or_initialize
@@ -22,6 +23,7 @@ class QBWC::ActiveRecord::Job < QBWC::Job
 
     jb = self.new(name, enabled, company, worker_class)
     jb.requests = requests.is_a?(Array) ? requests : [requests] unless requests.nil?
+    jb.data = data unless data.nil?
 
     jb
   end
@@ -60,6 +62,16 @@ class QBWC::ActiveRecord::Job < QBWC::Job
 
   def requests=(r)
     find_ar_job.update_all(:requests => r.to_yaml)
+    super
+  end
+
+  def data
+    find_ar_job.pluck(:data).first
+    super
+  end
+
+  def data=(r)
+    find_ar_job.update_all(:data => r.to_yaml)
     super
   end
 

--- a/lib/qbwc/active_record/job.rb
+++ b/lib/qbwc/active_record/job.rb
@@ -21,9 +21,9 @@ class QBWC::ActiveRecord::Job < QBWC::Job
     ar_job.worker_class = worker_class
     ar_job.save!
 
-    jb = self.new(name, enabled, company, worker_class)
+    jb = self.new(name, enabled, company, worker_class, requests, data)
     jb.requests = requests.is_a?(Array) ? requests : [requests] unless requests.nil?
-    jb.data = data unless data.nil?
+    jb.data = data
 
     jb
   end

--- a/lib/qbwc/active_record/job.rb
+++ b/lib/qbwc/active_record/job.rb
@@ -10,7 +10,8 @@ class QBWC::ActiveRecord::Job < QBWC::Job
   end
 
   # Creates and persists a job.
-  def self.add_job(name, enabled, company, worker_class)
+  def self.add_job(name, enabled, company, worker_class, requests)
+
     worker_class = worker_class.to_s
     ar_job = find_ar_job_with_name(name).first_or_initialize
     ar_job.company = company
@@ -18,7 +19,11 @@ class QBWC::ActiveRecord::Job < QBWC::Job
     ar_job.request_index = 0
     ar_job.worker_class = worker_class
     ar_job.save!
-    self.new(name, enabled, company, worker_class)
+
+    jb = self.new(name, enabled, company, worker_class)
+    jb.requests = requests.is_a?(Array) ? requests : [requests] unless requests.nil?
+
+    jb
   end
 
   def self.find_job_with_name(name)

--- a/lib/qbwc/active_record/job.rb
+++ b/lib/qbwc/active_record/job.rb
@@ -40,6 +40,11 @@ class QBWC::ActiveRecord::Job < QBWC::Job
     self.class.find_ar_job_with_name(name)
   end
 
+  def self.delete_job_with_name(name)
+    j = find_ar_job_with_name(name).first
+    j.destroy unless j.nil?
+  end
+
   def enabled=(value)
     find_ar_job.update_all(:enabled => value)
   end

--- a/lib/qbwc/active_record/job.rb
+++ b/lib/qbwc/active_record/job.rb
@@ -3,6 +3,7 @@ class QBWC::ActiveRecord::Job < QBWC::Job
     validates :name, :uniqueness => true, :presence => true
     serialize :requests, Array
     serialize :data
+    serialize :worker_requests_called
 
     def to_qbwc_job
       QBWC::ActiveRecord::Job.new(name, enabled, company, worker_class, requests, data)
@@ -19,6 +20,7 @@ class QBWC::ActiveRecord::Job < QBWC::Job
     ar_job.enabled = enabled
     ar_job.request_index = 0
     ar_job.worker_class = worker_class
+    ar_job.worker_requests_called = false
     ar_job.save!
 
     jb = self.new(name, enabled, company, worker_class, requests, data)
@@ -47,6 +49,10 @@ class QBWC::ActiveRecord::Job < QBWC::Job
     j.destroy unless j.nil?
   end
 
+  def get_persistent_value(attribute_name)
+    find_ar_job.pluck(attribute_name).first
+  end
+
   def enabled=(value)
     find_ar_job.update_all(:enabled => value)
   end
@@ -72,6 +78,16 @@ class QBWC::ActiveRecord::Job < QBWC::Job
 
   def data=(r)
     find_ar_job.update_all(:data => r.to_yaml)
+    super
+  end
+
+  def worker_requests_called
+    find_ar_job.pluck(:worker_requests_called).first
+    super
+  end
+
+  def worker_requests_called=(value)
+    find_ar_job.update_all(:worker_requests_called => value)
     super
   end
 

--- a/lib/qbwc/active_record/session.rb
+++ b/lib/qbwc/active_record/session.rb
@@ -14,7 +14,7 @@ class QBWC::ActiveRecord::Session < QBWC::Session
       # Restore current job from saved one on QbwcSession
       @current_job = QBWC.get_job(@session.current_job) if @session.current_job
       # Restore pending jobs from saved list on QbwcSession
-      @pending_jobs = @session.pending_jobs.split(',').map { |job_name| QBWC.get_job(job_name) }
+      @pending_jobs = @session.pending_jobs.split(',').map { |job_name| QBWC.get_job(job_name) }.select { |job| ! job.nil? }
       super(@session.user, @session.company, @session.ticket)
     else
       super

--- a/lib/qbwc/controller.rb
+++ b/lib/qbwc/controller.rb
@@ -97,6 +97,7 @@ QWC
         ticket = QBWC.storage_module::Session.new(user, company).ticket if company
         company ||= 'none'
         QBWC.logger.info "Company is '#{company}', ticket is '#{ticket}'."
+        QBWC.session_initializer.call unless QBWC.session_initializer.nil?
       else
         QBWC.logger.info "Authentication of user '#{params[:strUserName]}' failed."
       end

--- a/lib/qbwc/job.rb
+++ b/lib/qbwc/job.rb
@@ -7,6 +7,7 @@ class QBWC::Job
     @enabled = enabled
     @company = company || QBWC.company_file_path
     @worker_class = worker_class
+    @worker_requests_called = false
     @requests = requests
     @data = data
     @request_index = 0

--- a/lib/qbwc/job.rb
+++ b/lib/qbwc/job.rb
@@ -67,11 +67,15 @@ class QBWC::Job
 
   def next
     # Generate and save the requests to run when starting the job.
-    if requests.nil? || requests.empty?
+    unless @worker_requests_called
       r = worker.requests
-      r = [r] if r.is_a?(Hash)
-      self.requests = r
+      @worker_requests_called = true
+      unless r.nil?
+        r = [r] if r.is_a?(Hash)
+        self.requests = r
+      end
     end
+
     QBWC.logger.info("Requests available are '#{requests}'.")
     ri = request_index
     QBWC.logger.info("Request index is '#{ri}'.")
@@ -83,7 +87,7 @@ class QBWC::Job
 
   def reset
     self.request_index = 0
-    self.requests = []
+    #self.requests = []
   end
 
 end

--- a/lib/qbwc/job.rb
+++ b/lib/qbwc/job.rb
@@ -2,12 +2,13 @@ class QBWC::Job
 
   attr_reader :name, :company, :worker_class
 
-  def initialize(name, enabled, company, worker_class, requests = [])
+  def initialize(name, enabled, company, worker_class, requests = [], data = nil)
     @name = name
     @enabled = enabled
     @company = company || QBWC.company_file_path
     @worker_class = worker_class
     @requests = requests
+    @data = data
     @request_index = 0
   end
 
@@ -18,7 +19,7 @@ class QBWC::Job
   def process_response(response, session, advance)
     advance_next_request if advance
     QBWC.logger.info "Job '#{name}' received response: '#{response}'."
-    worker.handle_response(response, self)
+    worker.handle_response(response, self, data)
   end
 
   def advance_next_request
@@ -55,6 +56,14 @@ class QBWC::Job
 
   def requests=(r)
     @requests = r
+  end
+
+  def data
+    @data
+  end
+
+  def data=(d)
+    @data = d
   end
 
   def request_index

--- a/lib/qbwc/job.rb
+++ b/lib/qbwc/job.rb
@@ -7,7 +7,7 @@ class QBWC::Job
     @enabled = enabled
     @company = company || QBWC.company_file_path
     @worker_class = worker_class
-    @worker_requests_called = false
+    @worker_requests_called = get_persistent_value(:worker_requests_called)
     @requests = requests
     @data = data
     @request_index = 0
@@ -67,6 +67,14 @@ class QBWC::Job
     @data = d
   end
 
+  def worker_requests_called
+    @worker_requests_called
+  end
+
+  def worker_requests_called=(value)
+    @worker_requests_called = value
+  end
+
   def request_index
     @request_index
   end
@@ -77,9 +85,9 @@ class QBWC::Job
 
   def next_request
     # Generate and save the requests to run when starting the job.
-    unless @worker_requests_called
+    unless self.worker_requests_called
       r = worker.requests
-      @worker_requests_called = true
+      self.worker_requests_called = true
       unless r.nil?
         r = [r] if r.is_a?(Hash)
         self.requests = r

--- a/lib/qbwc/job.rb
+++ b/lib/qbwc/job.rb
@@ -74,7 +74,7 @@ class QBWC::Job
     @request_index = ri
   end
 
-  def next
+  def next_request
     # Generate and save the requests to run when starting the job.
     unless @worker_requests_called
       r = worker.requests
@@ -93,6 +93,7 @@ class QBWC::Job
     QBWC.logger.info("Next request is '#{nr}'.")
     return QBWC::Request.new(nr)
   end
+  alias :next :next_request  # Deprecated method name 'next'
 
   def reset
     self.request_index = 0

--- a/lib/qbwc/job.rb
+++ b/lib/qbwc/job.rb
@@ -18,7 +18,7 @@ class QBWC::Job
   def process_response(response, session, advance)
     advance_next_request if advance
     QBWC.logger.info "Job '#{name}' received response: '#{response}'."
-    worker.handle_response(response)
+    worker.handle_response(response, self)
   end
 
   def advance_next_request
@@ -79,7 +79,7 @@ class QBWC::Job
     QBWC.logger.info("Requests available are '#{requests}'.")
     ri = request_index
     QBWC.logger.info("Request index is '#{ri}'.")
-    return nil if requests.nil? || ri >= requests.length
+    return nil if ri.nil? || requests.nil? || ri >= requests.length
     nr = requests[ri]
     QBWC.logger.info("Next request is '#{nr}'.")
     return QBWC::Request.new(nr)

--- a/lib/qbwc/session.rb
+++ b/lib/qbwc/session.rb
@@ -27,18 +27,19 @@ class QBWC::Session
     self.progress == 100
   end
 
-  def next
+  def next_request
     return nil if current_job.nil?
-    until (request = current_job.next) do
+    until (request = current_job.next_request) do
       pending_jobs.shift
       reset(true) or break
     end
     self.progress = 100 if request.nil?
     request
   end
+  alias :next :next_request  # Deprecated method name 'next'
 
   def current_request
-    request = self.next
+    request = self.next_request
     if request && self.iterator_id.present?
       request = request.to_hash
       request.delete('xml_attributes')
@@ -57,7 +58,7 @@ class QBWC::Session
       parse_response_header(response)
       QBWC.logger.info "Processing response."
       self.current_job.process_response(response, self, iterator_id.blank? && (!self.error || QBWC::on_error == 'continueOnError'))
-      self.next unless self.error || self.iterator_id.present? # search next request
+      self.next_request unless self.error || self.iterator_id.present? # search next request
     rescue => e
       self.error = e.message
       QBWC.logger.warn "An error occured in QBWC::Session: #{e.message}"

--- a/lib/qbwc/worker.rb
+++ b/lib/qbwc/worker.rb
@@ -9,7 +9,7 @@ module QBWC
       true
     end
 
-    def handle_response(response)
+    def handle_response(response, job)
     end
 
   end

--- a/lib/qbwc/worker.rb
+++ b/lib/qbwc/worker.rb
@@ -9,7 +9,7 @@ module QBWC
       true
     end
 
-    def handle_response(response, job)
+    def handle_response(response, job, data)
     end
 
   end

--- a/spec/qbwc/session_spec.rb
+++ b/spec/qbwc/session_spec.rb
@@ -45,6 +45,10 @@ describe QBWC::Session do
 
   CUSTOMER_ADD_RESPONSE = "<?xml version=\"1.0\" ?><QBXML><QBXMLMsgsRs><CustomerAddRs statusCode=\"0\" statusSeverity=\"Info\" statusMessage=\"Status OK\"><CustomerRet><ListID>8000001B-1405768916</ListID><TimeCreated>2014-07-19T07:21:56-05:00</TimeCreated><TimeModified>2014-07-19T07:21:56-05:00</TimeModified><EditSequence>1405768916</EditSequence><Name>mrjoecustomer</Name><FullName>Joseph Customer</FullName><IsActive>true</IsActive><Sublevel>0</Sublevel><CompanyName>Joes Garage</CompanyName><Salutation>Mr</Salutation><FirstName>Joe</FirstName><LastName>Customer</LastName><BillAddress><Addr1>123 Main St.</Addr1><City>Mountain View</City><State>CA</State><PostalCode>94566</PostalCode></BillAddress><BillAddressBlock><Addr1>123 Main St.</Addr1><Addr2>Mountain View, CA 94566</Addr2></BillAddressBlock><Email>joecustomer@gmail.com</Email><Balance>0.00</Balance><TotalBalance>0.00</TotalBalance><AccountNumber>89087</AccountNumber><CreditLimit>2000.00</CreditLimit><JobStatus>None</JobStatus></CustomerRet></CustomerAddRs></QBXMLMsgsRs></QBXML>"
 
+  CUSTOMER_QUERY_RESPONSE_WARN = "<?xml version=\"1.0\" ?><QBXML><QBXMLMsgsRs><CustomerQueryRs statusCode=\"500\" statusSeverity=\"Warn\" statusMessage=\"The query request has not been fully completed. There was a required element (&quot;bleech&quot;) that could not be found in QuickBooks.\" /></QBXMLMsgsRs></QBXML>"
+
+  CUSTOMER_QUERY_RESPONSE_ERROR = "<?xml version=\"1.0\" ?><QBXML><QBXMLMsgsRs><CustomerQueryRs statusCode=\"3120\" statusSeverity=\"Error\" statusMessage=\"Object &quot;8000001B-1405768916&quot; specified in the request cannot be found.  QuickBooks error message: Invalid argument.  The specified record does not exist in the list.\" /></QBXMLMsgsRs></QBXML>"
+
   before do
     # http://stackoverflow.com/a/10605312
     ActiveRecord::Base.establish_connection(
@@ -93,6 +97,60 @@ describe QBWC::Session do
     session.response = CUSTOMER_ADD_RESPONSE
 
     expect(session.progress).to eq(100)
+  end
+
+  class QueryAndDeleteWorker < QBWC::Worker
+    def requests
+      {:name => 'mrjoecustomer'}
+    end
+
+    def handle_response(resp, job, data)
+       QBWC.delete_job(job.name)
+    end
+  end
+
+  it "processes warning responses and deletes the job" do
+    company = ''
+    qbwc_username = 'myUserName'
+
+    QBWC.api = :qb
+
+    # Add a job
+    QBWC.add_job(:query_joe_customer, true, company, QueryAndDeleteWorker)
+
+    # Simulate controller receive_response
+    ticket_string = QBWC::ActiveRecord::Session.new(qbwc_username, company).ticket
+    session = QBWC::Session.new(nil, company)
+
+    session.response = CUSTOMER_QUERY_RESPONSE_WARN
+    expect(session.progress).to eq(100)
+
+    # Simulate arbitrary controller action
+    session = QBWC::ActiveRecord::Session.get(ticket_string)  # simulated get_session
+    session.save  # simulated save_session
+
+  end
+
+  it "processes error responses and deletes the job" do
+    company = ''
+    qbwc_username = 'myUserName'
+
+    QBWC.api = :qb
+
+    # Add a job
+    QBWC.add_job(:query_joe_customer, true, company, QueryAndDeleteWorker)
+
+    # Simulate controller receive_response
+    ticket_string = QBWC::ActiveRecord::Session.new(qbwc_username, company).ticket
+    session = QBWC::Session.new(nil, company)
+
+    session.response = CUSTOMER_QUERY_RESPONSE_ERROR
+    expect(session.progress).to eq(0)
+
+    # Simulate controller get_last_error
+    session = QBWC::ActiveRecord::Session.get(ticket_string)  # simulated get_session
+    session.save  # simulated save_session
+
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,6 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 

--- a/test/qbwc/controllers/controller_test.rb
+++ b/test/qbwc/controllers/controller_test.rb
@@ -39,6 +39,16 @@ class QBWCControllerTest < ActionController::TestCase
     assert_equal 1, QBWC.pending_jobs(COMPANY).count
   end
 
+  test "authenticate with initialization block" do
+     initializer_called = false
+     QBWC.set_session_initializer() do
+        initializer_called = true
+     end
+
+    _authenticate
+    assert initializer_called
+  end
+
   test "send_request" do
     _authenticate_with_queued_job
 

--- a/test/qbwc/integration/job_management_test.rb
+++ b/test/qbwc/integration/job_management_test.rb
@@ -54,7 +54,7 @@ class JobManagementTest < ActionDispatch::IntegrationTest
       {:foo => 'bar'}
     end
 
-    def handle_response(resp, job)
+    def handle_response(resp, job, data)
       QBWC.delete_job(job.name)
     end
   end

--- a/test/qbwc/integration/job_management_test.rb
+++ b/test/qbwc/integration/job_management_test.rb
@@ -63,7 +63,7 @@ class JobManagementTest < ActionDispatch::IntegrationTest
     QBWC.add_job(:job_deletes_itself_after_running, true, COMPANY, DeleteJobWorker)
     assert_equal 1, QBWC.pending_jobs(COMPANY).length
     session = QBWC::Session.new('foo', COMPANY)
-    assert_not_nil session.next
+    assert_not_nil session.next_request
     simulate_response(session)
     assert_equal 0, QBWC.pending_jobs(COMPANY).length
   end

--- a/test/qbwc/integration/job_management_test.rb
+++ b/test/qbwc/integration/job_management_test.rb
@@ -41,4 +41,31 @@ class JobManagementTest < ActionDispatch::IntegrationTest
     assert_empty QBWC.jobs
   end
 
+  test "delete_job" do
+    jobname = :delete_job
+    QBWC.add_job(jobname, true, 'my-company', QBWC::Worker)
+    assert_not_nil QBWC.get_job(jobname)
+    QBWC.delete_job(jobname)
+    assert_nil QBWC.get_job(jobname)
+  end
+
+  class DeleteJobWorker < QBWC::Worker
+    def requests
+      {:foo => 'bar'}
+    end
+
+    def handle_response(resp, job)
+      QBWC.delete_job(job.name)
+    end
+  end
+
+  test "job deletes itself after running" do
+    QBWC.add_job(:job_deletes_itself_after_running, true, COMPANY, DeleteJobWorker)
+    assert_equal 1, QBWC.pending_jobs(COMPANY).length
+    session = QBWC::Session.new('foo', COMPANY)
+    assert_not_nil session.next
+    simulate_response(session)
+    assert_equal 0, QBWC.pending_jobs(COMPANY).length
+  end
+
 end

--- a/test/qbwc/integration/request_generation_test.rb
+++ b/test/qbwc/integration/request_generation_test.rb
@@ -157,10 +157,12 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
     QBWC.add_job(:integration_test_1, true, '', SingleRequestWorker)
     QBWC.add_job(:integration_test_2, true, '', MultipleRequestWorker)
     assert_equal 2, QBWC.jobs.length
+    QBWC.jobs.each {|job| assert job.worker_requests_called == false}
     session = QBWC::Session.new('foo', '')
 
     # one request from SingleRequestWorker
     assert_not_nil session.next_request
+    QBWC.jobs.each {|job| assert job.worker_requests_called == (job.name == 'integration_test_1') }
     simulate_response(session)
 
     # two requests from MultipleRequestWorker
@@ -172,6 +174,7 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
 
     assert_equal 1, $SINGLE_REQUESTS_INVOKED_COUNT
     assert_equal 1, $MULTIPLE_REQUESTS_INVOKED_COUNT
+    QBWC.jobs.each {|job| assert job.worker_requests_called == true}
   end  
 
   class ShouldntRunWorker < QBWC::Worker

--- a/test/qbwc/integration/request_generation_test.rb
+++ b/test/qbwc/integration/request_generation_test.rb
@@ -1,3 +1,4 @@
+$:<< File.expand_path(File.dirname(__FILE__) + '/../..')  # (for wash_out_helper.rb)
 require 'test_helper.rb'
 
 class RequestGenerationTest < ActionDispatch::IntegrationTest
@@ -21,6 +22,20 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
   test "worker with nothing" do
     QBWC.add_job(:integration_test, true, '', QBWC::Worker)
     session = QBWC::Session.new('foo', '')
+    assert_nil session.next
+  end
+
+  class NilRequestWorker < QBWC::Worker
+    def requests
+      nil
+    end
+  end
+
+  test "worker with nil" do
+    QBWC.add_job(:integration_test, true, '', NilRequestWorker)
+    session = QBWC::Session.new('foo', '')
+    assert_nil session.next
+    simulate_response(session)
     assert_nil session.next
   end
 
@@ -113,6 +128,101 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
     assert_not_nil session.next
     simulate_response(session)
     assert_nil session.next
+  end
+
+  class RequestsArgumentIgnoredByRequestWorker < QBWC::Worker
+    def requests
+      {:foo => 'bar'}
+    end
+  end
+
+  test "requests argument ignored by request worker when requests is non-nil" do
+    QBWC.add_job(:integration_test, true, '', RequestsArgumentIgnoredByRequestWorker, QBWC_CUSTOMER_ADD_RQ)
+    session = QBWC::Session.new('foo', '')
+    request = session.next
+    assert_not_nil request
+    assert_match /Foo.bar.\/Foo/, request.request
+    simulate_response(session)
+    assert_nil session.next
+
+    assert_equal [{:foo => 'bar'}], QBWC::ActiveRecord::Job::QbwcJob.first[:requests]
+  end
+
+  class RequestsArgumentOverridesRequestWorker < QBWC::Worker
+    def requests
+      nil
+    end
+  end
+
+  test "requests argument overrides request worker when requests is nil" do
+    QBWC.add_job(:integration_test, true, '', RequestsArgumentOverridesRequestWorker, QBWC_CUSTOMER_ADD_RQ)
+    session = QBWC::Session.new('foo', '')
+    request = session.next
+    assert_not_nil request
+    assert_match /Name.#{QBWC_USERNAME}.\/Name/, request.request
+    simulate_response(session)
+    assert_nil session.next
+
+    assert_equal [QBWC_CUSTOMER_ADD_RQ], QBWC::ActiveRecord::Job::QbwcJob.first[:requests]
+  end
+
+  class SimulatedUserModel
+    attr_accessor :name
+  end
+
+  class RequestsArgumentEstablishesRequestEarlyWorker < QBWC::Worker
+    def requests
+      nil
+    end
+  end
+
+  test "requests argument establishes request early" do
+    usr = SimulatedUserModel.new
+    usr.name = QBWC_USERNAME
+
+    QBWC.add_job(:integration_test, true, '', RequestsArgumentEstablishesRequestEarlyWorker, {:name => usr.name})
+    usr.name = 'bleech'
+
+    session = QBWC::Session.new('foo', '')
+    request = session.next
+    assert_match /Name.#{QBWC_USERNAME}.\/Name/, request.request
+
+    assert_equal [{:name => QBWC_USERNAME}], QBWC::ActiveRecord::Job::QbwcJob.first[:requests]
+  end
+
+  class RequestsArgumentReturnsMultipleRequestsWorker < QBWC::Worker
+    def requests
+      nil
+    end
+  end
+
+  test "requests argument returns multiple requests" do
+    usr1 = SimulatedUserModel.new
+    usr1.name = QBWC_USERNAME
+
+    usr2 = SimulatedUserModel.new
+    usr2.name = 'usr2 name'
+
+    multiple_requests = [
+      {:name => usr1.name},
+      {:name => usr2.name}
+    ]
+    QBWC.add_job(:integration_test, true, '', RequestsArgumentEstablishesRequestEarlyWorker, multiple_requests)
+    usr1.name = 'bleech'
+    usr2.name = 'bleech'
+
+    session = QBWC::Session.new('foo', '')
+    request1 = session.next
+    assert_match /Name.#{QBWC_USERNAME}.\/Name/, request1.request
+    simulate_response(session)
+
+    request2 = session.next
+    assert_match /Name.usr2 name.\/Name/, request2.request
+    simulate_response(session)
+
+    assert_nil session.next
+
+    assert_equal [{:name => QBWC_USERNAME}, {:name => 'usr2 name'}], QBWC::ActiveRecord::Job::QbwcJob.first[:requests]
   end
 
 end

--- a/test/qbwc/integration/request_generation_test.rb
+++ b/test/qbwc/integration/request_generation_test.rb
@@ -7,6 +7,9 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
     RequestGenerationTest.app = Rails.application
     Rails.logger = Logger.new('/dev/null')  # or STDOUT
     QBWC.clear_jobs
+
+    $HANDLE_RESPONSE_DATA = nil
+    $HANDLE_RESPONSE_IS_PASSED_DATA = false
   end
 
   test "worker with nothing" do
@@ -60,6 +63,26 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
     simulate_response(session)
     assert_nil session.next
     assert $HANDLE_RESPONSE_EXECUTED
+  end
+
+  class HandleResponseWithDataWorker < QBWC::Worker
+    def requests
+      {:foo => 'bar'}
+    end
+    def handle_response(response, job, data)
+      $HANDLE_RESPONSE_IS_PASSED_DATA = (data == $HANDLE_RESPONSE_DATA)
+    end
+  end
+
+  test "handle_response is passed data" do
+    $HANDLE_RESPONSE_DATA = {:first => {:second => 2, :third => '3'} }
+    $HANDLE_RESPONSE_IS_PASSED_DATA = false
+    QBWC.add_job(:integration_test, true, '', HandleResponseWithDataWorker, nil, $HANDLE_RESPONSE_DATA)
+    session = QBWC::Session.new('foo', '')
+    assert_not_nil session.next
+    simulate_response(session)
+    assert_nil session.next
+    assert $HANDLE_RESPONSE_IS_PASSED_DATA
   end
 
   class MultipleRequestWorker < QBWC::Worker

--- a/test/qbwc/integration/request_generation_test.rb
+++ b/test/qbwc/integration/request_generation_test.rb
@@ -15,7 +15,7 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
   test "worker with nothing" do
     QBWC.add_job(:integration_test, true, '', QBWC::Worker)
     session = QBWC::Session.new('foo', '')
-    assert_nil session.next
+    assert_nil session.next_request
   end
 
   class NilRequestWorker < QBWC::Worker
@@ -27,9 +27,9 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
   test "worker with nil" do
     QBWC.add_job(:integration_test, true, '', NilRequestWorker)
     session = QBWC::Session.new('foo', '')
-    assert_nil session.next
+    assert_nil session.next_request
     simulate_response(session)
-    assert_nil session.next
+    assert_nil session.next_request
   end
 
   class SingleRequestWorker < QBWC::Worker
@@ -42,9 +42,9 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
   test "simple request worker" do
     QBWC.add_job(:integration_test, true, '', SingleRequestWorker)
     session = QBWC::Session.new('foo', '')
-    assert_not_nil session.next
+    assert_not_nil session.next_request
     simulate_response(session)
-    assert_nil session.next
+    assert_nil session.next_request
   end
 
   class HandleResponseOmitsJobWorker < QBWC::Worker
@@ -60,9 +60,9 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
     $HANDLE_RESPONSE_EXECUTED = false
     QBWC.add_job(:integration_test, true, '', HandleResponseOmitsJobWorker)
     session = QBWC::Session.new('foo', '')
-    assert_not_nil session.next
+    assert_not_nil session.next_request
     simulate_response(session)
-    assert_nil session.next
+    assert_nil session.next_request
     assert $HANDLE_RESPONSE_EXECUTED
   end
 
@@ -80,9 +80,9 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
     $HANDLE_RESPONSE_IS_PASSED_DATA = false
     QBWC.add_job(:integration_test, true, '', HandleResponseWithDataWorker, nil, $HANDLE_RESPONSE_DATA)
     session = QBWC::Session.new('foo', '')
-    assert_not_nil session.next
+    assert_not_nil session.next_request
     simulate_response(session)
-    assert_nil session.next
+    assert_nil session.next_request
     assert $HANDLE_RESPONSE_IS_PASSED_DATA
   end
 
@@ -101,11 +101,11 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
 
     QBWC.add_job(:integration_test, true, '', MultipleRequestWorker)
     session = QBWC::Session.new('foo', '')
-    assert_not_nil session.next
+    assert_not_nil session.next_request
     simulate_response(session)
-    assert_not_nil session.next
+    assert_not_nil session.next_request
     simulate_response(session)
-    assert_nil session.next
+    assert_nil session.next_request
 
     assert_equal 1, $MULTIPLE_REQUESTS_INVOKED_COUNT
   end
@@ -120,15 +120,15 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
     session = QBWC::Session.new('foo', '')
 
     # one request from SingleRequestWorker
-    assert_not_nil session.next
+    assert_not_nil session.next_request
     simulate_response(session)
 
     # two requests from MultipleRequestWorker
-    assert_not_nil session.next
+    assert_not_nil session.next_request
     simulate_response(session)
-    assert_not_nil session.next
+    assert_not_nil session.next_request
     simulate_response(session)
-    assert_nil session.next
+    assert_nil session.next_request
 
     assert_equal 1, $SINGLE_REQUESTS_INVOKED_COUNT
     assert_equal 1, $MULTIPLE_REQUESTS_INVOKED_COUNT
@@ -150,7 +150,7 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
   test "shouldnt run worker" do
     QBWC.add_job(:integration_test, true, '', ShouldntRunWorker)
     session = QBWC::Session.new('foo', '')
-    assert_nil session.next
+    assert_nil session.next_request
   end
 
   $VARIABLE_REQUEST_COUNT = 2
@@ -167,13 +167,13 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
   test "variable request worker" do
     QBWC.add_job(:integration_test, true, '', VariableRequestWorker)
     session = QBWC::Session.new('foo', '')
-    assert_not_nil session.next
+    assert_not_nil session.next_request
     simulate_response(session)
     # The number of requests should be fixed after the job starts.
     $VARIABLE_REQUEST_COUNT = 5
-    assert_not_nil session.next
+    assert_not_nil session.next_request
     simulate_response(session)
-    assert_nil session.next
+    assert_nil session.next_request
   end
 
   class RequestsArgumentIgnoredByRequestWorker < QBWC::Worker
@@ -185,11 +185,11 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
   test "requests argument ignored by request worker when requests is non-nil" do
     QBWC.add_job(:integration_test, true, '', RequestsArgumentIgnoredByRequestWorker, QBWC_CUSTOMER_ADD_RQ)
     session = QBWC::Session.new('foo', '')
-    request = session.next
+    request = session.next_request
     assert_not_nil request
     assert_match /Foo.bar.\/Foo/, request.request
     simulate_response(session)
-    assert_nil session.next
+    assert_nil session.next_request
 
     assert_equal [{:foo => 'bar'}], QBWC::ActiveRecord::Job::QbwcJob.first[:requests]
   end
@@ -203,11 +203,11 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
   test "requests argument overrides request worker when requests is nil" do
     QBWC.add_job(:integration_test, true, '', RequestsArgumentOverridesRequestWorker, QBWC_CUSTOMER_ADD_RQ)
     session = QBWC::Session.new('foo', '')
-    request = session.next
+    request = session.next_request
     assert_not_nil request
     assert_match /Name.#{QBWC_USERNAME}.\/Name/, request.request
     simulate_response(session)
-    assert_nil session.next
+    assert_nil session.next_request
 
     assert_equal [QBWC_CUSTOMER_ADD_RQ], QBWC::ActiveRecord::Job::QbwcJob.first[:requests]
   end
@@ -230,7 +230,7 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
     usr.name = 'bleech'
 
     session = QBWC::Session.new('foo', '')
-    request = session.next
+    request = session.next_request
     assert_match /Name.#{QBWC_USERNAME}.\/Name/, request.request
 
     assert_equal [{:name => QBWC_USERNAME}], QBWC::ActiveRecord::Job::QbwcJob.first[:requests]
@@ -258,15 +258,15 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
     usr2.name = 'bleech'
 
     session = QBWC::Session.new('foo', '')
-    request1 = session.next
+    request1 = session.next_request
     assert_match /Name.#{QBWC_USERNAME}.\/Name/, request1.request
     simulate_response(session)
 
-    request2 = session.next
+    request2 = session.next_request
     assert_match /Name.usr2 name.\/Name/, request2.request
     simulate_response(session)
 
-    assert_nil session.next
+    assert_nil session.next_request
 
     assert_equal [{:name => QBWC_USERNAME}, {:name => 'usr2 name'}], QBWC::ActiveRecord::Job::QbwcJob.first[:requests]
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -131,3 +131,13 @@ def _authenticate_with_queued_job
 
   _authenticate
 end
+
+def simulate_response(session)
+  session.response = <<-EOF
+  <?xml version="1.0"?><?qbxml version="7.0"?>
+<QBXML>
+  <QBXMLMsgsRs onError="stopOnError">
+  </QBXMLMsgsRs>
+</QBXML>
+  EOF
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -127,9 +127,7 @@ end
 #-------------------------------------------
 def _authenticate_with_queued_job
   # Queue a job
-  QBWC.add_job(:customer_add_rq_job, true, COMPANY, QBWC::Worker) do
-    QBWC_CUSTOMER_ADD_RQ
-  end
+  QBWC.add_job(:customer_add_rq_job, true, COMPANY, QBWC::Worker)
 
   _authenticate
 end


### PR DESCRIPTION
The original qbwc gem supported passing optional requests to QBWC.add_job. This pull request restores a mostly similar functionality, primarily for backwards compatibility. Addresses #36. This functionality is implemented by commit https://github.com/rchekaluk/qbwc/commit/23af3e7f42cd89604fa9fe9863f733830535d9a1

These additional commits are needed in order to delete a job after it has run (as discussed [here](https://github.com/skryl/qbwc#creating-jobs)). This introduces a new _required_ parameter for handle_response in order to access the current job:
* https://github.com/rchekaluk/qbwc/commit/4314a911316d6b12140fb5a4e0c3cb031eb0c1fc
* https://github.com/rchekaluk/qbwc/commit/427564ccbfa4548cf0999f3464b8c66f9c44e251

This additional commit allows passing arbitrary data to handle_response, in order to access model attributes when handling responses (analogous to #36 for responses). This introduces a new optional parameter for handle_response:
* https://github.com/rchekaluk/qbwc/commit/a3bbdbd9c4a129789234168bf7c064e8438b1bdd

This additional commit creates new function set_session_initializer to perform arbitrary processing at the beginning of each QuickBooks Web Connector session:
* https://github.com/rchekaluk/qbwc/commit/5d9aed5b4f32a5cf4e0ec7891e799c635e04ce66

The remaining commits are cleanup only:
* https://github.com/rchekaluk/qbwc/commit/8c1ca137aae7bcb370f2e01cd5f8a13facd62391
* https://github.com/rchekaluk/qbwc/commit/d38b6cc5de9cf96f1ca2b62ef446034420066308
* https://github.com/rchekaluk/qbwc/commit/4ef5c1d829819364e34c536dd9e139f3007b61ff
