### PR TITLE
Permit passing optional requests when adding a job (REVISED)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Use the [Onscreen Reference for Intuit Software Development Kits](https://develo
 
 You can optionally provide requests directly to QBWC.add_job. If provided, these requests can return a single qbxml request, or an array of qbxml requests.
 
-Any non-nil worker requests override those passed to add_job; if the worker requests method returns a non-nil value, then this value will be used to create the request (and the requests passed to add_job will be ignored).
+The worker requests method overrides requests passed to add_job; if the worker requests method returns a non-nil value, then this value will be used to create the request (and the requests passed to add_job will be ignored).
 
 ### Check versions ###
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ A job is associated to a worker, which is an object descending from `QBWC::Worke
 - `should_run?` - whether this job should run (e.g. you can have a job run only under certain circumstances) - returns `Boolean` and defaults to `true`.
 - `handle_response(response)` - defines what to do with the response from Quickbooks.
 
+All three methods are not invoked until a QuickBooks Web Connector session has been established with your web service.
+
 A sample worker to get a list of customers from QuickBooks:
 
 ```ruby
@@ -87,11 +89,11 @@ After adding a job, it will remain active and will run every time QuickBooks Web
 
 Use the [Onscreen Reference for Intuit Software Development Kits](https://developer-static.intuit.com/qbSDK-current/Common/newOSR/index.html) (use Format: qbXML) to see request and response formats to use in your jobs. Use underscored, lowercased versions of all tags (e.g. `customer_query_rq`, not `CustomerQueryRq`).
 
-### Requests passed to add_job ###
+### Referencing memory values when constructing requests ###
 
-You can optionally provide requests directly to QBWC.add_job. If provided, these requests can return a single qbxml request, or an array of qbxml requests.
+A QBWC::Worker#requests method cannot access values that are in-memory (local variables, model attributes, etc.) at the time that QBWC.add_job is called; however, in lieu of using QBWC::Worker#requests, you can optionally construct and pass requests directly to QBWC.add_job (scalar request or array of requests). These requests will be immediately persisted by QBWC.add_job (in contrast to requests constructed by QBWC::Worker#requests, which are persisted during a QuickBooks Web Connector session).
 
-The worker requests method overrides requests passed to add_job; if the worker requests method returns a non-nil value, then this value will be used to create the request (and the requests passed to add_job will be ignored).
+A QBWC::Worker#requests method overrides any requests passed to QBWC.add_job; if QBWC::Worker#requests returns a non-nil value, then this value will be sent to QuickBooks Web Connector (and any requests passed directly to QBWC.add_job will be ignored).
 
 ### Check versions ###
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Use the [Onscreen Reference for Intuit Software Development Kits](https://develo
 
 A QBWC::Worker#requests method cannot access values that are in-memory (local variables, model attributes, etc.) at the time that QBWC.add_job is called; however, in lieu of using QBWC::Worker#requests, you can optionally construct and pass requests directly to QBWC.add_job (scalar request or array of requests). These requests will be immediately persisted by QBWC.add_job (in contrast to requests constructed by QBWC::Worker#requests, which are persisted during a QuickBooks Web Connector session).
 
-A QBWC::Worker#requests method overrides any requests passed to QBWC.add_job; if QBWC::Worker#requests returns a non-nil value, then this value will be sent to QuickBooks Web Connector (and any requests passed directly to QBWC.add_job will be ignored).
+If requests are passed to QBWC.add_job, any QBWC::Worker#requests method will be ignored and will not be invoked during QuickBooks Web Connector sessions.
 
 ### Check versions ###
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ After adding a job, it will remain active and will run every time QuickBooks Web
 
 Use the [Onscreen Reference for Intuit Software Development Kits](https://developer-static.intuit.com/qbSDK-current/Common/newOSR/index.html) (use Format: qbXML) to see request and response formats to use in your jobs. Use underscored, lowercased versions of all tags (e.g. `customer_query_rq`, not `CustomerQueryRq`).
 
+### Requests passed to add_job ###
+
+You can optionally provide requests directly to QBWC.add_job. If provided, these requests can return a single qbxml request, or an array of qbxml requests.
+
+Any non-nil worker requests override those passed to add_job; if the worker requests method returns a non-nil value, then this value will be used to create the request (and the requests passed to add_job will be ignored).
+
 ### Check versions ###
 
 If you want to return server version or check client version you can override server_version_response or check_client_version methods in your controller. Check QB web connector guide for allowed responses.

--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ Use the [Onscreen Reference for Intuit Software Development Kits](https://develo
 
 ### Referencing memory values when constructing requests ###
 
-A QBWC::Worker#requests method cannot access values that are in-memory (local variables, model attributes, etc.) at the time that QBWC.add_job is called; however, in lieu of using QBWC::Worker#requests, you can optionally construct and pass requests directly to QBWC.add_job (scalar request or array of requests). These requests will be immediately persisted by QBWC.add_job (in contrast to requests constructed by QBWC::Worker#requests, which are persisted during a QuickBooks Web Connector session).
+A `QBWC::Worker#requests` method cannot access values that are in-memory (global variables, local variables, model attributes, etc.) at the time that QBWC.add_job is called; however, in lieu of using `QBWC::Worker#requests`, you can optionally construct and pass requests directly to `QBWC.add_job` (Hash, String, or array of Hashes and Strings). These requests will be immediately persisted by `QBWC.add_job` (in contrast to requests constructed by `QBWC::Worker#requests`, which are persisted during a QuickBooks Web Connector session).
 
-If requests are passed to QBWC.add_job, any QBWC::Worker#requests method will be ignored and will not be invoked during QuickBooks Web Connector sessions.
+If requests are passed to `QBWC.add_job`, any `QBWC::Worker#requests` method will be ignored and will not be invoked during QuickBooks Web Connector sessions.
 
 ### Check versions ###
 

--- a/lib/generators/qbwc/install/templates/db/migrate/create_qbwc_jobs.rb
+++ b/lib/generators/qbwc/install/templates/db/migrate/create_qbwc_jobs.rb
@@ -7,7 +7,7 @@ class CreateQbwcJobs < ActiveRecord::Migration
       t.boolean :enabled, :null => false, :default => false
       t.integer :request_index, :null => false, :default => 0
       t.text :requests
-      t.boolean :requests_provided_when_job_added
+      t.boolean :requests_provided_when_job_added, :null => false, :default => false
       t.timestamps
     end
   end

--- a/lib/generators/qbwc/install/templates/db/migrate/create_qbwc_jobs.rb
+++ b/lib/generators/qbwc/install/templates/db/migrate/create_qbwc_jobs.rb
@@ -7,6 +7,7 @@ class CreateQbwcJobs < ActiveRecord::Migration
       t.boolean :enabled, :null => false, :default => false
       t.integer :request_index, :null => false, :default => 0
       t.text :requests
+      t.boolean :requests_provided_when_job_added
       t.timestamps
     end
   end

--- a/lib/qbwc.rb
+++ b/lib/qbwc.rb
@@ -60,8 +60,8 @@ module QBWC
       storage_module::Job.list_jobs
     end
 
-    def add_job(name, enabled, company, klass)
-      storage_module::Job.add_job(name, enabled, company, klass)
+    def add_job(name, enabled = true, company = nil, klass = QBWC::Worker, requests = nil)
+      storage_module::Job.add_job(name, enabled, company, klass, requests)
     end
 
     def get_job(name)

--- a/lib/qbwc/active_record/job.rb
+++ b/lib/qbwc/active_record/job.rb
@@ -20,7 +20,7 @@ class QBWC::ActiveRecord::Job < QBWC::Job
     ar_job.worker_class = worker_class
     ar_job.save!
 
-    jb = self.new(name, enabled, company, worker_class)
+    jb = self.new(name, enabled, company, worker_class, requests)
     jb.requests = requests.is_a?(Array) ? requests : [requests] unless requests.nil?
 
     jb

--- a/lib/qbwc/active_record/job.rb
+++ b/lib/qbwc/active_record/job.rb
@@ -2,6 +2,7 @@ class QBWC::ActiveRecord::Job < QBWC::Job
   class QbwcJob < ActiveRecord::Base
     validates :name, :uniqueness => true, :presence => true
     serialize :requests, Array
+    serialize :requests_provided_when_job_added
 
     def to_qbwc_job
       QBWC::ActiveRecord::Job.new(name, enabled, company, worker_class, requests)
@@ -22,6 +23,7 @@ class QBWC::ActiveRecord::Job < QBWC::Job
 
     jb = self.new(name, enabled, company, worker_class, requests)
     jb.requests = requests.is_a?(Array) ? requests : [requests] unless requests.nil?
+    jb.requests_provided_when_job_added = (! requests.nil?)
 
     jb
   end
@@ -40,6 +42,10 @@ class QBWC::ActiveRecord::Job < QBWC::Job
     self.class.find_ar_job_with_name(name)
   end
 
+  def get_persistent_value(attribute_name)
+    find_ar_job.pluck(attribute_name).first
+  end
+
   def enabled=(value)
     find_ar_job.update_all(:enabled => value)
   end
@@ -55,6 +61,16 @@ class QBWC::ActiveRecord::Job < QBWC::Job
 
   def requests=(r)
     find_ar_job.update_all(:requests => r.to_yaml)
+    super
+  end
+
+  def requests_provided_when_job_added
+    find_ar_job.pluck(:requests_provided_when_job_added).first
+    super
+  end
+
+  def requests_provided_when_job_added=(value)
+    find_ar_job.update_all(:requests_provided_when_job_added => value)
     super
   end
 

--- a/lib/qbwc/active_record/job.rb
+++ b/lib/qbwc/active_record/job.rb
@@ -10,7 +10,8 @@ class QBWC::ActiveRecord::Job < QBWC::Job
   end
 
   # Creates and persists a job.
-  def self.add_job(name, enabled, company, worker_class)
+  def self.add_job(name, enabled, company, worker_class, requests)
+
     worker_class = worker_class.to_s
     ar_job = find_ar_job_with_name(name).first_or_initialize
     ar_job.company = company
@@ -18,7 +19,11 @@ class QBWC::ActiveRecord::Job < QBWC::Job
     ar_job.request_index = 0
     ar_job.worker_class = worker_class
     ar_job.save!
-    self.new(name, enabled, company, worker_class)
+
+    jb = self.new(name, enabled, company, worker_class)
+    jb.requests = requests.is_a?(Array) ? requests : [requests] unless requests.nil?
+
+    jb
   end
 
   def self.find_job_with_name(name)

--- a/lib/qbwc/active_record/job.rb
+++ b/lib/qbwc/active_record/job.rb
@@ -2,7 +2,6 @@ class QBWC::ActiveRecord::Job < QBWC::Job
   class QbwcJob < ActiveRecord::Base
     validates :name, :uniqueness => true, :presence => true
     serialize :requests, Array
-    serialize :requests_provided_when_job_added
 
     def to_qbwc_job
       QBWC::ActiveRecord::Job.new(name, enabled, company, worker_class, requests)
@@ -23,7 +22,7 @@ class QBWC::ActiveRecord::Job < QBWC::Job
 
     jb = self.new(name, enabled, company, worker_class, requests)
     jb.requests = requests.is_a?(Array) ? requests : [requests] unless requests.nil?
-    jb.requests_provided_when_job_added = (! requests.nil?)
+    jb.requests_provided_when_job_added = (! requests.nil? && ! requests.empty?)
 
     jb
   end
@@ -40,10 +39,6 @@ class QBWC::ActiveRecord::Job < QBWC::Job
 
   def find_ar_job
     self.class.find_ar_job_with_name(name)
-  end
-
-  def get_persistent_value(attribute_name)
-    find_ar_job.pluck(attribute_name).first
   end
 
   def enabled=(value)
@@ -66,7 +61,7 @@ class QBWC::ActiveRecord::Job < QBWC::Job
 
   def requests_provided_when_job_added
     find_ar_job.pluck(:requests_provided_when_job_added).first
-    super
+    #super
   end
 
   def requests_provided_when_job_added=(value)

--- a/lib/qbwc/job.rb
+++ b/lib/qbwc/job.rb
@@ -67,11 +67,15 @@ class QBWC::Job
 
   def next
     # Generate and save the requests to run when starting the job.
-    if requests.nil? || requests.empty?
+    unless @worker_requests_called
       r = worker.requests
-      r = [r] if r.is_a?(Hash)
-      self.requests = r
+      @worker_requests_called = true
+      unless r.nil?
+        r = [r] if r.is_a?(Hash)
+        self.requests = r
+      end
     end
+
     QBWC.logger.info("Requests available are '#{requests}'.")
     ri = request_index
     QBWC.logger.info("Request index is '#{ri}'.")
@@ -83,7 +87,7 @@ class QBWC::Job
 
   def reset
     self.request_index = 0
-    self.requests = []
+    #self.requests = []
   end
 
 end

--- a/lib/qbwc/job.rb
+++ b/lib/qbwc/job.rb
@@ -9,6 +9,7 @@ class QBWC::Job
     @worker_class = worker_class
     @requests = requests
     @request_index = 0
+    @requests_provided_when_job_added = get_persistent_value(:requests_provided_when_job_added)
   end
 
   def worker
@@ -65,15 +66,20 @@ class QBWC::Job
     @request_index = ri
   end
 
+  def requests_provided_when_job_added
+    @requests_provided_when_job_added
+  end
+
+  def requests_provided_when_job_added=(value)
+    @requests_provided_when_job_added = value
+  end
+
   def next
     # Generate and save the requests to run when starting the job.
-    unless @worker_requests_called
+    if (requests.nil? || requests.empty?) && ! self.requests_provided_when_job_added
       r = worker.requests
-      @worker_requests_called = true
-      unless r.nil?
-        r = [r] if r.is_a?(Hash)
-        self.requests = r
-      end
+      r = [r] if r.is_a?(Hash)
+      self.requests = r
     end
 
     QBWC.logger.info("Requests available are '#{requests}'.")

--- a/lib/qbwc/job.rb
+++ b/lib/qbwc/job.rb
@@ -92,7 +92,7 @@ class QBWC::Job
 
   def reset
     self.request_index = 0
-    #self.requests = []
+    self.requests = [] unless self.requests_provided_when_job_added
   end
 
 end

--- a/lib/qbwc/job.rb
+++ b/lib/qbwc/job.rb
@@ -9,7 +9,6 @@ class QBWC::Job
     @worker_class = worker_class
     @requests = requests
     @request_index = 0
-    @requests_provided_when_job_added = get_persistent_value(:requests_provided_when_job_added)
   end
 
   def worker

--- a/test/qbwc/integration/request_generation_test.rb
+++ b/test/qbwc/integration/request_generation_test.rb
@@ -216,15 +216,15 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
     usr = SimulatedUserModel.new
     usr.name = QBWC_USERNAME
 
-    QBWC.add_job(:integration_test, true, '', RequestsArgumentEstablishesRequestEarlyWorker, {:name => usr.name})
+    QBWC.add_job(:integration_test, true, '', RequestsArgumentEstablishesRequestEarlyWorker, {:customer_query_rq => {:full_name => QBWC_USERNAME}})
     QBWC.jobs.each {|job| assert job.requests_provided_when_job_added == true}
     usr.name = 'bleech'
 
     session = QBWC::Session.new('foo', '')
     request = session.next
-    assert_match /Name.#{QBWC_USERNAME}.\/Name/, request.request
+    assert_match /FullName.#{QBWC_USERNAME}.\/FullName/, request.request
 
-    assert_equal [{:name => QBWC_USERNAME}], QBWC::ActiveRecord::Job::QbwcJob.first[:requests]
+    assert_equal [{:customer_query_rq => {:full_name => QBWC_USERNAME}}], QBWC::ActiveRecord::Job::QbwcJob.first[:requests]
     QBWC.jobs.each {|job| assert job.requests_provided_when_job_added == true}
   end
 
@@ -242,8 +242,8 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
     usr2.name = 'usr2 name'
 
     multiple_requests = [
-      {:name => usr1.name},
-      {:name => usr2.name}
+      {:customer_query_rq => {:full_name => usr1.name}},
+      {:customer_query_rq => {:full_name => usr2.name}}
     ]
     QBWC.add_job(:integration_test, true, '', RequestsArgumentEstablishesRequestEarlyWorker, multiple_requests)
     QBWC.jobs.each {|job| assert job.requests_provided_when_job_added == true}
@@ -252,16 +252,17 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
 
     session = QBWC::Session.new('foo', '')
     request1 = session.next
-    assert_match /Name.#{QBWC_USERNAME}.\/Name/, request1.request
+    assert_match /FullName.#{QBWC_USERNAME}.\/FullName/, request1.request
     simulate_response(session)
 
     request2 = session.next
-    assert_match /Name.usr2 name.\/Name/, request2.request
+    assert_match /FullName.usr2 name.\/FullName/, request2.request
     simulate_response(session)
 
     assert_nil session.next
 
-    assert_equal [{:name => QBWC_USERNAME}, {:name => 'usr2 name'}], QBWC::ActiveRecord::Job::QbwcJob.first[:requests]
+    assert_equal multiple_requests[0], QBWC::ActiveRecord::Job::QbwcJob.first[:requests][0]
+    assert_equal multiple_requests[1], QBWC::ActiveRecord::Job::QbwcJob.first[:requests][1]
     QBWC.jobs.each {|job| assert job.requests_provided_when_job_added == true}
   end
 

--- a/test/qbwc/integration/request_generation_test.rb
+++ b/test/qbwc/integration/request_generation_test.rb
@@ -1,3 +1,4 @@
+$:<< File.expand_path(File.dirname(__FILE__) + '/../..')  # (for wash_out_helper.rb)
 require 'test_helper.rb'
 
 class RequestGenerationTest < ActionDispatch::IntegrationTest
@@ -21,6 +22,20 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
   test "worker with nothing" do
     QBWC.add_job(:integration_test, true, '', QBWC::Worker)
     session = QBWC::Session.new('foo', '')
+    assert_nil session.next
+  end
+
+  class NilRequestWorker < QBWC::Worker
+    def requests
+      nil
+    end
+  end
+
+  test "worker with nil" do
+    QBWC.add_job(:integration_test, true, '', NilRequestWorker)
+    session = QBWC::Session.new('foo', '')
+    assert_nil session.next
+    simulate_response(session)
     assert_nil session.next
   end
 
@@ -113,6 +128,101 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
     assert_not_nil session.next
     simulate_response(session)
     assert_nil session.next
+  end
+
+  class RequestsArgumentIgnoredByRequestWorker < QBWC::Worker
+    def requests
+      {:foo => 'bar'}
+    end
+  end
+
+  test "requests argument ignored by request worker when requests is non-nil" do
+    QBWC.add_job(:integration_test, true, '', RequestsArgumentIgnoredByRequestWorker, QBWC_CUSTOMER_ADD_RQ)
+    session = QBWC::Session.new('foo', '')
+    request = session.next
+    assert_not_nil request
+    assert_match /Foo.bar.\/Foo/, request.request
+    simulate_response(session)
+    assert_nil session.next
+
+    assert_equal [{:foo => 'bar'}], QBWC::ActiveRecord::Job::QbwcJob.first[:requests]
+  end
+
+  class RequestsArgumentOverridesRequestWorker < QBWC::Worker
+    def requests
+      nil
+    end
+  end
+
+  test "requests argument overrides request worker when requests is nil" do
+    QBWC.add_job(:integration_test, true, '', RequestsArgumentOverridesRequestWorker, QBWC_CUSTOMER_ADD_RQ)
+    session = QBWC::Session.new('foo', '')
+    request = session.next
+    assert_not_nil request
+    assert_match /Name.#{QBWC_USERNAME}.\/Name/, request.request
+    simulate_response(session)
+    assert_nil session.next
+
+    assert_equal [QBWC_CUSTOMER_ADD_RQ], QBWC::ActiveRecord::Job::QbwcJob.first[:requests]
+  end
+
+  class SimulatedUserModel
+    attr_accessor :name
+  end
+
+  class RequestsArgumentEstablishesRequestEarlyWorker < QBWC::Worker
+    def requests
+      nil
+    end
+  end
+
+  test "requests argument establishes request early" do
+    usr = SimulatedUserModel.new
+    usr.name = QBWC_USERNAME
+
+    QBWC.add_job(:integration_test, true, '', RequestsArgumentEstablishesRequestEarlyWorker, {:name => usr.name})
+    usr.name = 'bleech'
+
+    session = QBWC::Session.new('foo', '')
+    request = session.next
+    assert_match /Name.#{QBWC_USERNAME}.\/Name/, request.request
+
+    assert_equal [{:name => QBWC_USERNAME}], QBWC::ActiveRecord::Job::QbwcJob.first[:requests]
+  end
+
+  class RequestsArgumentReturnsMultipleRequestsWorker < QBWC::Worker
+    def requests
+      nil
+    end
+  end
+
+  test "requests argument returns multiple requests" do
+    usr1 = SimulatedUserModel.new
+    usr1.name = QBWC_USERNAME
+
+    usr2 = SimulatedUserModel.new
+    usr2.name = 'usr2 name'
+
+    multiple_requests = [
+      {:name => usr1.name},
+      {:name => usr2.name}
+    ]
+    QBWC.add_job(:integration_test, true, '', RequestsArgumentEstablishesRequestEarlyWorker, multiple_requests)
+    usr1.name = 'bleech'
+    usr2.name = 'bleech'
+
+    session = QBWC::Session.new('foo', '')
+    request1 = session.next
+    assert_match /Name.#{QBWC_USERNAME}.\/Name/, request1.request
+    simulate_response(session)
+
+    request2 = session.next
+    assert_match /Name.usr2 name.\/Name/, request2.request
+    simulate_response(session)
+
+    assert_nil session.next
+
+    assert_equal [{:name => QBWC_USERNAME}, {:name => 'usr2 name'}], QBWC::ActiveRecord::Job::QbwcJob.first[:requests]
   end
 
 end

--- a/test/qbwc/integration/request_generation_test.rb
+++ b/test/qbwc/integration/request_generation_test.rb
@@ -41,6 +41,7 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
 
   class SingleRequestWorker < QBWC::Worker
     def requests
+      $SINGLE_REQUESTS_INVOKED_COUNT += 1 if $SINGLE_REQUESTS_INVOKED_COUNT.is_a?(Integer)
       {:foo => 'bar'}
     end
   end
@@ -55,6 +56,7 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
 
   class MultipleRequestWorker < QBWC::Worker
     def requests
+      $MULTIPLE_REQUESTS_INVOKED_COUNT += 1 if $MULTIPLE_REQUESTS_INVOKED_COUNT.is_a?(Integer)
       [
         {:foo => 'bar'},
         {:bar => 'foo'}
@@ -63,6 +65,8 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
   end
 
   test "multiple request worker" do
+    $MULTIPLE_REQUESTS_INVOKED_COUNT = 0
+
     QBWC.add_job(:integration_test, true, '', MultipleRequestWorker)
     session = QBWC::Session.new('foo', '')
     assert_not_nil session.next
@@ -70,22 +74,32 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
     assert_not_nil session.next
     simulate_response(session)
     assert_nil session.next
+
+    assert_equal 1, $MULTIPLE_REQUESTS_INVOKED_COUNT
   end
 
   test 'multiple jobs' do
+    $SINGLE_REQUESTS_INVOKED_COUNT   = 0
+    $MULTIPLE_REQUESTS_INVOKED_COUNT = 0
+
     QBWC.add_job(:integration_test_1, true, '', SingleRequestWorker)
     QBWC.add_job(:integration_test_2, true, '', MultipleRequestWorker)
     assert_equal 2, QBWC.jobs.length
     session = QBWC::Session.new('foo', '')
-    # one from SingleRequestWorker
+
+    # one request from SingleRequestWorker
     assert_not_nil session.next
     simulate_response(session)
-    # two from MultipleRequestWorker
+
+    # two requests from MultipleRequestWorker
     assert_not_nil session.next
     simulate_response(session)
     assert_not_nil session.next
     simulate_response(session)
     assert_nil session.next
+
+    assert_equal 1, $SINGLE_REQUESTS_INVOKED_COUNT
+    assert_equal 1, $MULTIPLE_REQUESTS_INVOKED_COUNT
   end  
 
   class ShouldntRunWorker < QBWC::Worker

--- a/test/qbwc/integration/request_generation_test.rb
+++ b/test/qbwc/integration/request_generation_test.rb
@@ -77,6 +77,16 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
     assert_nil session.next
 
     assert_equal 1, $MULTIPLE_REQUESTS_INVOKED_COUNT
+
+    # requests should be generated once per session
+    session2 = QBWC::Session.new('foo', '')
+    assert_not_nil session2.next
+    simulate_response(session2)
+    assert_not_nil session2.next
+    simulate_response(session2)
+    assert_nil session2.next
+
+    assert_equal 2, $MULTIPLE_REQUESTS_INVOKED_COUNT
   end
 
   test 'multiple jobs' do


### PR DESCRIPTION
The original qbwc gem supported passing optional requests to QBWC.add_job. This pull request restores a mostly similar functionality, primarily for backwards compatibility. Addresses #36.

Revision of https://github.com/skryl/qbwc/pull/38
