### PR TITLE
Add QBWC.delete_job

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A job is associated to a worker, which is an object descending from `QBWC::Worke
 
 - `requests` - defines the request(s) that QuickBooks should process - returns a `Hash` or an `Array` of `Hash`es.
 - `should_run?` - whether this job should run (e.g. you can have a job run only under certain circumstances) - returns `Boolean` and defaults to `true`.
-- `handle_response(response)` - defines what to do with the response from Quickbooks.
+- `handle_response(response, job)` - defines what to do with the response from Quickbooks.
 
 All three methods are not invoked until a QuickBooks Web Connector session has been established with your web service.
 
@@ -64,7 +64,7 @@ class CustomerTestWorker < QBWC::Worker
 		}
 	end
 
-	def handle_response(r)
+	def handle_response(r, job)
 		# handle_response will get customers in groups of 100. When this is 0, we're done.
 		complete = r['xml_attributes']['iteratorRemainingCount'] == '0'
 
@@ -85,7 +85,15 @@ require 'qbwc'
 QBWC.add_job(:list_customers, false, '', CustomerTestWorker)
 ```
 
-After adding a job, it will remain active and will run every time QuickBooks Web Connector runs an update. If you don't want this to happen, you can have custom logic in your worker's `should_run?` or have your job disable or delete itself after completion. 
+After adding a job, it will remain active and will run every time QuickBooks Web Connector runs an update. If you don't want this to happen, you can have custom logic in your worker's `should_run?` or have your job disable or delete itself after completion. For example:
+
+```ruby
+	def handle_response(r, job)
+		QBWC.delete_job(job.name)
+	end
+
+```
+
 
 Use the [Onscreen Reference for Intuit Software Development Kits](https://developer-static.intuit.com/qbSDK-current/Common/newOSR/index.html) (use Format: qbXML) to see request and response formats to use in your jobs. Use underscored, lowercased versions of all tags (e.g. `customer_query_rq`, not `CustomerQueryRq`).
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ After adding a job, it will remain active and will run every time QuickBooks Web
 
 ```ruby
 	def handle_response(r, job)
-		QBWC.delete_job(job.name)
+		QBWC.delete_job(job)
 	end
 
 ```

--- a/lib/qbwc.rb
+++ b/lib/qbwc.rb
@@ -68,7 +68,8 @@ module QBWC
       storage_module::Job.find_job_with_name(name)
     end
 
-    def delete_job(name)
+    def delete_job(object_or_name)
+      name = (object_or_name.is_a?(Job) ? object_or_name.name : object_or_name)
       storage_module::Job.delete_job_with_name(name)
     end
 

--- a/lib/qbwc.rb
+++ b/lib/qbwc.rb
@@ -68,6 +68,10 @@ module QBWC
       storage_module::Job.find_job_with_name(name)
     end
 
+    def delete_job(name)
+      storage_module::Job.delete_job_with_name(name)
+    end
+
     def pending_jobs(company)
       js = jobs
       QBWC.logger.info "#{js.length} jobs exist, checking for pending jobs for company '#{company}'."

--- a/lib/qbwc/active_record/job.rb
+++ b/lib/qbwc/active_record/job.rb
@@ -42,6 +42,11 @@ class QBWC::ActiveRecord::Job < QBWC::Job
     self.class.find_ar_job_with_name(name)
   end
 
+  def self.delete_job_with_name(name)
+    j = find_ar_job_with_name(name).first
+    j.destroy unless j.nil?
+  end
+
   def get_persistent_value(attribute_name)
     find_ar_job.pluck(attribute_name).first
   end

--- a/lib/qbwc/active_record/session.rb
+++ b/lib/qbwc/active_record/session.rb
@@ -14,7 +14,7 @@ class QBWC::ActiveRecord::Session < QBWC::Session
       # Restore current job from saved one on QbwcSession
       @current_job = QBWC.get_job(@session.current_job) if @session.current_job
       # Restore pending jobs from saved list on QbwcSession
-      @pending_jobs = @session.pending_jobs.split(',').map { |job_name| QBWC.get_job(job_name) }
+      @pending_jobs = @session.pending_jobs.split(',').map { |job_name| QBWC.get_job(job_name) }.select { |job| ! job.nil? }
       super(@session.user, @session.company, @session.ticket)
     else
       super

--- a/lib/qbwc/job.rb
+++ b/lib/qbwc/job.rb
@@ -19,7 +19,7 @@ class QBWC::Job
   def process_response(response, session, advance)
     advance_next_request if advance
     QBWC.logger.info "Job '#{name}' received response: '#{response}'."
-    worker.handle_response(response)
+    worker.handle_response(response, self)
   end
 
   def advance_next_request
@@ -85,7 +85,7 @@ class QBWC::Job
     QBWC.logger.info("Requests available are '#{requests}'.")
     ri = request_index
     QBWC.logger.info("Request index is '#{ri}'.")
-    return nil if requests.nil? || ri >= requests.length
+    return nil if ri.nil? || requests.nil? || ri >= requests.length
     nr = requests[ri]
     QBWC.logger.info("Next request is '#{nr}'.")
     return QBWC::Request.new(nr)

--- a/lib/qbwc/worker.rb
+++ b/lib/qbwc/worker.rb
@@ -9,7 +9,7 @@ module QBWC
       true
     end
 
-    def handle_response(response)
+    def handle_response(response, job)
     end
 
   end

--- a/spec/qbwc/session_spec.rb
+++ b/spec/qbwc/session_spec.rb
@@ -45,6 +45,10 @@ describe QBWC::Session do
 
   CUSTOMER_ADD_RESPONSE = "<?xml version=\"1.0\" ?><QBXML><QBXMLMsgsRs><CustomerAddRs statusCode=\"0\" statusSeverity=\"Info\" statusMessage=\"Status OK\"><CustomerRet><ListID>8000001B-1405768916</ListID><TimeCreated>2014-07-19T07:21:56-05:00</TimeCreated><TimeModified>2014-07-19T07:21:56-05:00</TimeModified><EditSequence>1405768916</EditSequence><Name>mrjoecustomer</Name><FullName>Joseph Customer</FullName><IsActive>true</IsActive><Sublevel>0</Sublevel><CompanyName>Joes Garage</CompanyName><Salutation>Mr</Salutation><FirstName>Joe</FirstName><LastName>Customer</LastName><BillAddress><Addr1>123 Main St.</Addr1><City>Mountain View</City><State>CA</State><PostalCode>94566</PostalCode></BillAddress><BillAddressBlock><Addr1>123 Main St.</Addr1><Addr2>Mountain View, CA 94566</Addr2></BillAddressBlock><Email>joecustomer@gmail.com</Email><Balance>0.00</Balance><TotalBalance>0.00</TotalBalance><AccountNumber>89087</AccountNumber><CreditLimit>2000.00</CreditLimit><JobStatus>None</JobStatus></CustomerRet></CustomerAddRs></QBXMLMsgsRs></QBXML>"
 
+  CUSTOMER_QUERY_RESPONSE_WARN = "<?xml version=\"1.0\" ?><QBXML><QBXMLMsgsRs><CustomerQueryRs statusCode=\"500\" statusSeverity=\"Warn\" statusMessage=\"The query request has not been fully completed. There was a required element (&quot;bleech&quot;) that could not be found in QuickBooks.\" /></QBXMLMsgsRs></QBXML>"
+
+  CUSTOMER_QUERY_RESPONSE_ERROR = "<?xml version=\"1.0\" ?><QBXML><QBXMLMsgsRs><CustomerQueryRs statusCode=\"3120\" statusSeverity=\"Error\" statusMessage=\"Object &quot;8000001B-1405768916&quot; specified in the request cannot be found.  QuickBooks error message: Invalid argument.  The specified record does not exist in the list.\" /></QBXMLMsgsRs></QBXML>"
+
   before do
     # http://stackoverflow.com/a/10605312
     ActiveRecord::Base.establish_connection(
@@ -107,6 +111,60 @@ describe QBWC::Session do
     session.response = CUSTOMER_ADD_RESPONSE
 
     session.progress.should == 100
+  end
+
+  class QueryAndDeleteWorker < QBWC::Worker
+    def requests
+      {:name => 'mrjoecustomer'}
+    end
+
+    def handle_response(resp, job, data)
+       QBWC.delete_job(job.name)
+    end
+  end
+
+  it "processes warning responses and deletes the job" do
+    company = ''
+    qbwc_username = 'myUserName'
+
+    QBWC.api = :qb
+
+    # Add a job
+    QBWC.add_job(:query_joe_customer, true, company, QueryAndDeleteWorker)
+
+    # Simulate controller receive_response
+    ticket_string = QBWC::ActiveRecord::Session.new(qbwc_username, company).ticket
+    session = QBWC::Session.new(nil, company)
+
+    session.response = CUSTOMER_QUERY_RESPONSE_WARN
+    expect(session.progress).to eq(100)
+
+    # Simulate arbitrary controller action
+    session = QBWC::ActiveRecord::Session.get(ticket_string)  # simulated get_session
+    session.save  # simulated save_session
+
+  end
+
+  it "processes error responses and deletes the job" do
+    company = ''
+    qbwc_username = 'myUserName'
+
+    QBWC.api = :qb
+
+    # Add a job
+    QBWC.add_job(:query_joe_customer, true, company, QueryAndDeleteWorker)
+
+    # Simulate controller receive_response
+    ticket_string = QBWC::ActiveRecord::Session.new(qbwc_username, company).ticket
+    session = QBWC::Session.new(nil, company)
+
+    session.response = CUSTOMER_QUERY_RESPONSE_ERROR
+    expect(session.progress).to eq(0)
+
+    # Simulate controller get_last_error
+    session = QBWC::ActiveRecord::Session.get(ticket_string)  # simulated get_session
+    session.save  # simulated save_session
+
   end
 
 end

--- a/test/qbwc/integration/job_management_test.rb
+++ b/test/qbwc/integration/job_management_test.rb
@@ -51,7 +51,7 @@ class JobManagementTest < ActionDispatch::IntegrationTest
 
   class DeleteJobWorker < QBWC::Worker
     def requests
-      {:foo => 'bar'}
+      {:customer_query_rq => {:full_name => 'Quincy Bob William Carlos'}}
     end
 
     def handle_response(resp, job)

--- a/test/qbwc/integration/job_management_test.rb
+++ b/test/qbwc/integration/job_management_test.rb
@@ -41,4 +41,31 @@ class JobManagementTest < ActionDispatch::IntegrationTest
     assert_empty QBWC.jobs
   end
 
+  test "delete_job" do
+    jobname = :delete_job
+    QBWC.add_job(jobname, true, 'my-company', QBWC::Worker)
+    assert_not_nil QBWC.get_job(jobname)
+    QBWC.delete_job(jobname)
+    assert_nil QBWC.get_job(jobname)
+  end
+
+  class DeleteJobWorker < QBWC::Worker
+    def requests
+      {:foo => 'bar'}
+    end
+
+    def handle_response(resp, job)
+      QBWC.delete_job(job.name)
+    end
+  end
+
+  test "job deletes itself after running" do
+    QBWC.add_job(:job_deletes_itself_after_running, true, COMPANY, DeleteJobWorker)
+    assert_equal 1, QBWC.pending_jobs(COMPANY).length
+    session = QBWC::Session.new('foo', COMPANY)
+    assert_not_nil session.next
+    simulate_response(session)
+    assert_equal 0, QBWC.pending_jobs(COMPANY).length
+  end
+
 end

--- a/test/qbwc/integration/job_management_test.rb
+++ b/test/qbwc/integration/job_management_test.rb
@@ -41,12 +41,26 @@ class JobManagementTest < ActionDispatch::IntegrationTest
     assert_empty QBWC.jobs
   end
 
-  test "delete_job" do
+  test "delete_job by name" do
     jobname = :delete_job
     QBWC.add_job(jobname, true, 'my-company', QBWC::Worker)
     assert_not_nil QBWC.get_job(jobname)
     QBWC.delete_job(jobname)
     assert_nil QBWC.get_job(jobname)
+
+    # Degenerate case does not crash
+    QBWC.delete_job('')
+  end
+
+  test "delete_job by object" do
+    jobname = :delete_job
+    QBWC.add_job(jobname, true, 'my-company', QBWC::Worker)
+    job = QBWC.get_job(jobname)
+    QBWC.delete_job(job)
+    assert_nil QBWC.get_job(jobname)
+
+    # Degenerate case does not crash
+    QBWC.delete_job(nil)
   end
 
   class DeleteJobWorker < QBWC::Worker

--- a/test/qbwc/integration/request_generation_test.rb
+++ b/test/qbwc/integration/request_generation_test.rb
@@ -47,7 +47,7 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
 
   class HandleResponseOmitsJobWorker < QBWC::Worker
     def requests
-      {:foo => 'bar'}
+      {:customer_query_rq => {:full_name => 'Quincy Bob William Carlos'}}
     end
     def handle_response(*response)
       $HANDLE_RESPONSE_EXECUTED = true

--- a/test/qbwc/integration/request_generation_test.rb
+++ b/test/qbwc/integration/request_generation_test.rb
@@ -9,16 +9,6 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
     QBWC.clear_jobs
   end
 
-  def simulate_response(session)
-    session.response = <<-EOF
-    <?xml version="1.0"?><?qbxml version="7.0"?>
-<QBXML>
-  <QBXMLMsgsRs onError="stopOnError">
-  </QBXMLMsgsRs>
-</QBXML>
-    EOF
-  end
-
   test "worker with nothing" do
     QBWC.add_job(:integration_test, true, '', QBWC::Worker)
     session = QBWC::Session.new('foo', '')
@@ -53,6 +43,25 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
     assert_not_nil session.next
     simulate_response(session)
     assert_nil session.next
+  end
+
+  class HandleResponseOmitsJobWorker < QBWC::Worker
+    def requests
+      {:foo => 'bar'}
+    end
+    def handle_response(*response)
+      $HANDLE_RESPONSE_EXECUTED = true
+    end
+  end
+
+  test "handle_response must use splat operator when omitting job argument" do
+    $HANDLE_RESPONSE_EXECUTED = false
+    QBWC.add_job(:integration_test, true, '', HandleResponseOmitsJobWorker)
+    session = QBWC::Session.new('foo', '')
+    assert_not_nil session.next
+    simulate_response(session)
+    assert_nil session.next
+    assert $HANDLE_RESPONSE_EXECUTED
   end
 
   class MultipleRequestWorker < QBWC::Worker

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -133,3 +133,13 @@ def _authenticate_with_queued_job
 
   _authenticate
 end
+
+def simulate_response(session)
+  session.response = <<-EOF
+  <?xml version="1.0"?><?qbxml version="7.0"?>
+<QBXML>
+  <QBXMLMsgsRs onError="stopOnError">
+  </QBXMLMsgsRs>
+</QBXML>
+  EOF
+end


### PR DESCRIPTION
Allow a job to delete itself after completion (as discussed [here](https://github.com/skryl/qbwc#creating-jobs)). This introduces a new required parameter for handle_response in order to access the current job: