### PR TITLE
Permit passing optional data for response handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A job is associated to a worker, which is an object descending from `QBWC::Worke
 
 - `requests` - defines the request(s) that QuickBooks should process - returns a `Hash` or an `Array` of `Hash`es.
 - `should_run?` - whether this job should run (e.g. you can have a job run only under certain circumstances) - returns `Boolean` and defaults to `true`.
-- `handle_response(response, job)` - defines what to do with the response from Quickbooks.
+- `handle_response(response, job, data)` - defines what to do with the response from Quickbooks.
 
 All three methods are not invoked until a QuickBooks Web Connector session has been established with your web service.
 
@@ -64,7 +64,7 @@ class CustomerTestWorker < QBWC::Worker
 		}
 	end
 
-	def handle_response(r, job)
+	def handle_response(r, job, data)
 		# handle_response will get customers in groups of 100. When this is 0, we're done.
 		complete = r['xml_attributes']['iteratorRemainingCount'] == '0'
 
@@ -88,7 +88,7 @@ QBWC.add_job(:list_customers, false, '', CustomerTestWorker)
 After adding a job, it will remain active and will run every time QuickBooks Web Connector runs an update. If you don't want this to happen, you can have custom logic in your worker's `should_run?` or have your job disable or delete itself after completion. For example:
 
 ```ruby
-	def handle_response(r, job)
+	def handle_response(r, job, data)
 		QBWC.delete_job(job)
 	end
 
@@ -102,6 +102,10 @@ Use the [Onscreen Reference for Intuit Software Development Kits](https://develo
 A `QBWC::Worker#requests` method cannot access values that are in-memory (global variables, local variables, model attributes, etc.) at the time that QBWC.add_job is called; however, in lieu of using `QBWC::Worker#requests`, you can optionally construct and pass requests directly to `QBWC.add_job` (Hash, String, or array of Hashes and Strings). These requests will be immediately persisted by `QBWC.add_job` (in contrast to requests constructed by `QBWC::Worker#requests`, which are persisted during a QuickBooks Web Connector session).
 
 If requests are passed to `QBWC.add_job`, any `QBWC::Worker#requests` method will be ignored and will not be invoked during QuickBooks Web Connector sessions.
+
+### Data passed to add_job ###
+
+You can optionally provide arbitrary data directly to QBWC.add_job. If provided, this data will be passed to handle_response.
 
 ### Check versions ###
 

--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ A `QBWC::Worker#requests` method cannot access values that are in-memory (global
 
 If requests are passed to `QBWC.add_job`, any `QBWC::Worker#requests` method will be ignored and will not be invoked during QuickBooks Web Connector sessions.
 
-### Data passed to add_job ###
+### Referencing memory values when handling responses ###
 
-You can optionally provide arbitrary data directly to QBWC.add_job. If provided, this data will be passed to handle_response.
+Similarly, a `QBWC::Worker#handle_response` method cannot access values that are in-memory at the time that `QBWC.add_job` is called; however, you can optionally pass arbitrary (serializable) data values to `QBWC.add_job`. This data will immediately be serialized and persisted by `QBWC.add_job`, then later deserialized and passed to `QBWC::Worker#handle_response` during a QuickBooks Web Connector session.
 
 ### Check versions ###
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ If requests are passed to `QBWC.add_job`, any `QBWC::Worker#requests` method wil
 
 ### Referencing memory values when handling responses ###
 
-Similarly, a `QBWC::Worker#handle_response` method cannot access values that are in-memory at the time that `QBWC.add_job` is called; however, you can optionally pass arbitrary (serializable) data values to `QBWC.add_job`. This data will immediately be serialized and persisted by `QBWC.add_job`, then later deserialized and passed to `QBWC::Worker#handle_response` during a QuickBooks Web Connector session.
+Similarly, a `QBWC::Worker#handle_response` method cannot access variables that are in-memory at the time that `QBWC.add_job` is called; however, you can optionally pass a serializable value (for example, String, Array, or Hash) to `QBWC.add_job`. This data will immediately be persisted by `QBWC.add_job`, then later passed to `QBWC::Worker#handle_response` during a QuickBooks Web Connector session.
 
 ### Check versions ###
 

--- a/lib/generators/qbwc/install/templates/db/migrate/create_qbwc_jobs.rb
+++ b/lib/generators/qbwc/install/templates/db/migrate/create_qbwc_jobs.rb
@@ -8,6 +8,7 @@ class CreateQbwcJobs < ActiveRecord::Migration
       t.integer :request_index, :null => false, :default => 0
       t.text :requests
       t.boolean :requests_provided_when_job_added, :null => false, :default => false
+      t.text :data
       t.timestamps
     end
   end

--- a/lib/qbwc.rb
+++ b/lib/qbwc.rb
@@ -60,8 +60,8 @@ module QBWC
       storage_module::Job.list_jobs
     end
 
-    def add_job(name, enabled = true, company = nil, klass = QBWC::Worker, requests = nil)
-      storage_module::Job.add_job(name, enabled, company, klass, requests)
+    def add_job(name, enabled = true, company = nil, klass = QBWC::Worker, requests = nil, data = nil)
+      storage_module::Job.add_job(name, enabled, company, klass, requests, data)
     end
 
     def get_job(name)

--- a/lib/qbwc/active_record/job.rb
+++ b/lib/qbwc/active_record/job.rb
@@ -21,10 +21,10 @@ class QBWC::ActiveRecord::Job < QBWC::Job
     ar_job.worker_class = worker_class
     ar_job.save!
 
-    jb = self.new(name, enabled, company, worker_class, requests)
+    jb = self.new(name, enabled, company, worker_class, requests, data)
     jb.requests = requests.is_a?(Array) ? requests : [requests] unless requests.nil?
     jb.requests_provided_when_job_added = (! requests.nil? && ! requests.empty?)
-    jb.data = data unless data.nil?
+    jb.data = data
 
     jb
   end

--- a/lib/qbwc/active_record/job.rb
+++ b/lib/qbwc/active_record/job.rb
@@ -2,15 +2,16 @@ class QBWC::ActiveRecord::Job < QBWC::Job
   class QbwcJob < ActiveRecord::Base
     validates :name, :uniqueness => true, :presence => true
     serialize :requests, Array
+    serialize :data
 
     def to_qbwc_job
-      QBWC::ActiveRecord::Job.new(name, enabled, company, worker_class, requests)
+      QBWC::ActiveRecord::Job.new(name, enabled, company, worker_class, requests, data)
     end
 
   end
 
   # Creates and persists a job.
-  def self.add_job(name, enabled, company, worker_class, requests)
+  def self.add_job(name, enabled, company, worker_class, requests, data)
 
     worker_class = worker_class.to_s
     ar_job = find_ar_job_with_name(name).first_or_initialize
@@ -23,6 +24,7 @@ class QBWC::ActiveRecord::Job < QBWC::Job
     jb = self.new(name, enabled, company, worker_class, requests)
     jb.requests = requests.is_a?(Array) ? requests : [requests] unless requests.nil?
     jb.requests_provided_when_job_added = (! requests.nil? && ! requests.empty?)
+    jb.data = data unless data.nil?
 
     jb
   end
@@ -71,6 +73,16 @@ class QBWC::ActiveRecord::Job < QBWC::Job
 
   def requests_provided_when_job_added=(value)
     find_ar_job.update_all(:requests_provided_when_job_added => value)
+    super
+  end
+
+  def data
+    find_ar_job.pluck(:data).first
+    super
+  end
+
+  def data=(r)
+    find_ar_job.update_all(:data => r.to_yaml)
     super
   end
 

--- a/lib/qbwc/job.rb
+++ b/lib/qbwc/job.rb
@@ -2,12 +2,13 @@ class QBWC::Job
 
   attr_reader :name, :company, :worker_class
 
-  def initialize(name, enabled, company, worker_class, requests = [])
+  def initialize(name, enabled, company, worker_class, requests = [], data = nil)
     @name = name
     @enabled = enabled
     @company = company || QBWC.company_file_path
     @worker_class = worker_class
     @requests = requests
+    @data = data
     @request_index = 0
   end
 
@@ -18,7 +19,7 @@ class QBWC::Job
   def process_response(response, session, advance)
     advance_next_request if advance
     QBWC.logger.info "Job '#{name}' received response: '#{response}'."
-    worker.handle_response(response, self)
+    worker.handle_response(response, self, data)
   end
 
   def advance_next_request
@@ -55,6 +56,14 @@ class QBWC::Job
 
   def requests=(r)
     @requests = r
+  end
+
+  def data
+    @data
+  end
+
+  def data=(d)
+    @data = d
   end
 
   def request_index

--- a/lib/qbwc/worker.rb
+++ b/lib/qbwc/worker.rb
@@ -9,7 +9,7 @@ module QBWC
       true
     end
 
-    def handle_response(response, job)
+    def handle_response(response, job, data)
     end
 
   end

--- a/test/qbwc/integration/job_management_test.rb
+++ b/test/qbwc/integration/job_management_test.rb
@@ -68,7 +68,7 @@ class JobManagementTest < ActionDispatch::IntegrationTest
       {:customer_query_rq => {:full_name => 'Quincy Bob William Carlos'}}
     end
 
-    def handle_response(resp, job)
+    def handle_response(resp, job, data)
       QBWC.delete_job(job.name)
     end
   end

--- a/test/qbwc/integration/request_generation_test.rb
+++ b/test/qbwc/integration/request_generation_test.rb
@@ -69,7 +69,7 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
 
   class HandleResponseWithDataWorker < QBWC::Worker
     def requests
-      {:foo => 'bar'}
+      {:customer_query_rq => {:full_name => 'Quincy Bob William Carlos'}}
     end
     def handle_response(response, job, data)
       $HANDLE_RESPONSE_IS_PASSED_DATA = (data == $HANDLE_RESPONSE_DATA)


### PR DESCRIPTION
This allows passing arbitrary data to handle_response, in order to access model attributes when handling responses (analogous to #36 for responses). This introduces a new optional parameter for handle_response.