### PR TITLE
Allow specifying arbitrary code to be executed at the start of each session

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,17 @@ If requests are passed to `QBWC.add_job`, any `QBWC::Worker#requests` method wil
 
 Similarly, a `QBWC::Worker#handle_response` method cannot access variables that are in-memory at the time that `QBWC.add_job` is called; however, you can optionally pass a serializable value (for example, String, Array, or Hash) to `QBWC.add_job`. This data will immediately be persisted by `QBWC.add_job`, then later passed to `QBWC::Worker#handle_response` during a QuickBooks Web Connector session.
 
+### Sessions ###
+
+You may optionally specify an initialization block that will be called when each QuickBooks Web Connector session is established:
+
+```ruby
+	QBWC.set_session_initializer() do
+          puts "New QuickBooks Web Connector session has been established"
+        end
+
+```
+
 ### Check versions ###
 
 If you want to return server version or check client version you can override server_version_response or check_client_version methods in your controller. Check QB web connector guide for allowed responses.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ You assign this initialization code either (a) during configuration, and/or (b) 
 In config/initializers/qbwc.rb:
 
 ```ruby
-c.session_initializer = Proc.new{||
+c.session_initializer = Proc.new{|session|
   puts "New QuickBooks Web Connector session has been established (configured session initializer)"
 }
 ```
@@ -125,7 +125,7 @@ In application code:
 ```ruby
         require 'qbwc'
 
-	QBWC.set_session_initializer() do
+	QBWC.set_session_initializer() do |session|
           puts "New QuickBooks Web Connector session has been established (overridden session initializer)"
           @information_from_jobs = {}
         end if the_application_needs_a_different_session_initializer

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Similarly, a `QBWC::Worker#handle_response` method cannot access variables that 
 
 ### Sessions ###
 
-In certain cases, you may want to perform some initialization prior to each QuickBooks Web Connector session (a QuickBooks Web Connector session is established when you manually run (update) an application's web service in QuickBooks Web Connector, or when QuickBooks Web Connector automatically executes a scheduled update). For this purpose, you may optionally provide an initialization block that will be invoked once when each QuickBooks Web Connector session is established, and prior to executing any queued jobs.
+In certain cases, you may want to perform some initialization prior to each QuickBooks Web Connector session. For this purpose, you may optionally provide an initialization block that will be invoked once when each QuickBooks Web Connector session is established, and prior to executing any queued jobs.
 
 You assign this initialization block prior to any QuickBooks Web Connector session being established, outside of any `QBWC::Worker` classes. For example:
 
@@ -122,6 +122,8 @@ You assign this initialization block prior to any QuickBooks Web Connector sessi
         QBWC.add_job(:list_customers, false, '', CustomerTestWorker)
 
 ```
+
+Note: a QuickBooks Web Connector session is established when you manually run (update) an application's web service in QuickBooks Web Connector, or when QuickBooks Web Connector automatically executes a scheduled update.
 
 ### Check versions ###
 

--- a/README.md
+++ b/README.md
@@ -109,19 +109,32 @@ Similarly, a `QBWC::Worker#handle_response` method cannot access variables that 
 
 ### Sessions ###
 
-In certain cases, you may want to perform some initialization prior to each QuickBooks Web Connector session. For this purpose, you may optionally provide an initialization block that will be invoked once when each QuickBooks Web Connector session is established, and prior to executing any queued jobs.
+In certain cases, you may want to perform some initialization prior to each QuickBooks Web Connector session. For this purpose, you may optionally provide initialization code that will be invoked once when each QuickBooks Web Connector session is established, and prior to executing any queued jobs.
 
-You assign this initialization block prior to any QuickBooks Web Connector session being established, outside of any `QBWC::Worker` classes. For example:
+You assign this initialization code either (a) during configuration, and/or (b) in application code by calling `set_session_initializer` (prior to any QuickBooks Web Connector session being established). For example:
+
+In config/initializers/qbwc.rb:
 
 ```ruby
+c.session_initializer = Proc.new{||
+  puts "New QuickBooks Web Connector session has been established (configured session initializer)"
+}
+```
+
+In application code:
+```ruby
         require 'qbwc'
+
 	QBWC.set_session_initializer() do
-          puts "New QuickBooks Web Connector session has been established"
+          puts "New QuickBooks Web Connector session has been established (overridden session initializer)"
           @information_from_jobs = {}
-        end
+        end if the_application_needs_a_different_session_initializer
+
         QBWC.add_job(:list_customers, false, '', CustomerTestWorker)
 
 ```
+
+Note: If you `set_session initializer` in your application code, you're only affecting the process that your application code runs in. A request to another process (e.g. if you're multiprocess or you restarted the server) means that QBWC won't see the session initializer.
 
 Note: a QuickBooks Web Connector session is established when you manually run (update) an application's web service in QuickBooks Web Connector, or when QuickBooks Web Connector automatically executes a scheduled update.
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Similarly, a `QBWC::Worker#handle_response` method cannot access variables that 
 
 ### Sessions ###
 
-In certain cases, you may want to perform some initialization prior to each QuickBooks Web Connector session. For this purpose, you may optionally provide initialization code that will be invoked once when each QuickBooks Web Connector session is established, and prior to executing any queued jobs.
+In certain cases, you may want to perform some initialization prior to each QuickBooks Web Connector session. For this purpose, you may optionally provide initialization code that will be invoked once when each QuickBooks Web Connector session is established, and prior to executing any queued jobs. This initialization code will not be invoked for any session in which no jobs are queued.
 
 You assign this initialization code either (a) during configuration, and/or (b) in application code by calling `set_session_initializer` (prior to any QuickBooks Web Connector session being established). For example:
 

--- a/README.md
+++ b/README.md
@@ -109,12 +109,17 @@ Similarly, a `QBWC::Worker#handle_response` method cannot access variables that 
 
 ### Sessions ###
 
-You may optionally specify an initialization block that will be called when each QuickBooks Web Connector session is established:
+In certain cases, you may want to perform some initialization prior to each QuickBooks Web Connector session (a QuickBooks Web Connector session is established when you manually run (update) an application's web service in QuickBooks Web Connector, or when QuickBooks Web Connector automatically executes a scheduled update). For this purpose, you may optionally provide an initialization block that will be invoked once when each QuickBooks Web Connector session is established, and prior to executing any queued jobs.
+
+You assign this initialization block prior to any QuickBooks Web Connector session being established, outside of any `QBWC::Worker` classes. For example:
 
 ```ruby
+        require 'qbwc'
 	QBWC.set_session_initializer() do
           puts "New QuickBooks Web Connector session has been established"
+          @information_from_jobs = {}
         end
+        QBWC.add_job(:list_customers, false, '', CustomerTestWorker)
 
 ```
 

--- a/lib/generators/qbwc/install/templates/config/qbwc.rb
+++ b/lib/generators/qbwc/install/templates/config/qbwc.rb
@@ -19,6 +19,12 @@ QBWC.configure do |c|
   #   next nil
   # }
 
+  # Code to execute after each session is authenticated
+  # Can be re-assigned by calling QBWC.set_session_initializer
+  # c.session_initializer = Proc.new{||
+  #   puts "New QuickBooks Web Connector session has been established"
+  # }
+
   # QBXML version to use. Check the "Implementation" column in the QuickBooks Onscreen Reference to see which fields are supported in which versions. Newer versions of QuickBooks are backwards compatible with older QBXML versions.
   c.min_version = "7.0"
   

--- a/lib/generators/qbwc/install/templates/config/qbwc.rb
+++ b/lib/generators/qbwc/install/templates/config/qbwc.rb
@@ -21,7 +21,7 @@ QBWC.configure do |c|
 
   # Code to execute after each session is authenticated
   # Can be re-assigned by calling QBWC.set_session_initializer
-  # c.session_initializer = Proc.new{||
+  # c.session_initializer = Proc.new{|session|
   #   puts "New QuickBooks Web Connector session has been established"
   # }
 

--- a/lib/qbwc.rb
+++ b/lib/qbwc.rb
@@ -36,6 +36,9 @@ module QBWC
   mattr_accessor :minutes_to_run
   @@minutes_to_run = 5
   
+  mattr_reader :session_initializer
+  @@session_initializer = nil
+
   mattr_reader :on_error
   @@on_error = 'stopOnError'
 
@@ -80,6 +83,11 @@ module QBWC
       storage_module::Job.sort_in_time_order(js.select {|job| job.company == company && job.pending?})
     end
     
+    def set_session_initializer(&block)
+      @@session_initializer = block
+      self
+    end
+
     def on_error=(reaction)
       raise 'Quickbooks on_error must be :stop or :continue' unless [:stop, :continue].include?(reaction)
       @@on_error = "stopOnError" if reaction == :stop

--- a/lib/qbwc.rb
+++ b/lib/qbwc.rb
@@ -51,7 +51,7 @@ module QBWC
   @@minutes_to_run = nil
 
   # Code to execute after each session is authenticated
-  mattr_reader :session_initializer
+  mattr_accessor :session_initializer
   @@session_initializer = nil
 
   # In the event of an error running requests, :stop all work or :continue with the next request?

--- a/lib/qbwc/controller.rb
+++ b/lib/qbwc/controller.rb
@@ -118,7 +118,6 @@ QWC
       elsif !QBWC.pending_jobs(company_file_path).present?
         QBWC.logger.info "Authentication of user '#{username}' succeeded, but no jobs pending for '#{company_file_path}'."
         company_file_path = AUTHENTICATE_NO_WORK
-        QBWC.session_initializer.call(nil) unless QBWC.session_initializer.nil?
       else
         QBWC.logger.info "Authentication of user '#{username}' succeeded, jobs are pending for '#{company_file_path}'."
         ticket = QBWC.storage_module::Session.new(username, company_file_path).ticket

--- a/lib/qbwc/controller.rb
+++ b/lib/qbwc/controller.rb
@@ -97,6 +97,7 @@ QWC
         ticket = QBWC.storage_module::Session.new(user, company).ticket if company
         company ||= 'none'
         QBWC.logger.info "Company is '#{company}', ticket is '#{ticket}'."
+        QBWC.session_initializer.call unless QBWC.session_initializer.nil?
       else
         QBWC.logger.info "Authentication of user '#{params[:strUserName]}' failed."
       end

--- a/lib/qbwc/controller.rb
+++ b/lib/qbwc/controller.rb
@@ -118,11 +118,11 @@ QWC
       elsif !QBWC.pending_jobs(company_file_path).present?
         QBWC.logger.info "Authentication of user '#{username}' succeeded, but no jobs pending for '#{company_file_path}'."
         company_file_path = AUTHENTICATE_NO_WORK
-        QBWC.session_initializer.call unless QBWC.session_initializer.nil?
+        QBWC.session_initializer.call(nil) unless QBWC.session_initializer.nil?
       else
         QBWC.logger.info "Authentication of user '#{username}' succeeded, jobs are pending for '#{company_file_path}'."
         ticket = QBWC.storage_module::Session.new(username, company_file_path).ticket
-        QBWC.session_initializer.call unless QBWC.session_initializer.nil?
+        QBWC.session_initializer.call(get_session(ticket)) unless QBWC.session_initializer.nil?
       end
       render :soap => {"tns:authenticateResult" => {"tns:string" => [ticket || '', company_file_path]}}
     end
@@ -161,8 +161,8 @@ QWC
 
     protected
 
-    def get_session
-      @session = QBWC.storage_module::Session.get(params[:ticket])
+    def get_session(ticket = params[:ticket])
+      @session = QBWC.storage_module::Session.get(ticket)
     end
 
     def save_session

--- a/test/qbwc/controllers/controller_test.rb
+++ b/test/qbwc/controllers/controller_test.rb
@@ -56,6 +56,23 @@ class QBWCControllerTest < ActionController::TestCase
     assert initializer_called
   end
 
+  test "most recent initialization block is executed" do
+     initializer1_called = false
+     initializer2_called = false
+
+     QBWC.set_session_initializer() do
+        initializer1_called = true
+     end
+
+     QBWC.set_session_initializer() do
+        initializer2_called = true
+     end
+
+    _authenticate
+    assert ! initializer1_called
+    assert   initializer2_called
+  end
+
   test "send_request" do
     _authenticate_with_queued_job
 

--- a/test/qbwc/controllers/controller_test.rb
+++ b/test/qbwc/controllers/controller_test.rb
@@ -39,6 +39,16 @@ class QBWCControllerTest < ActionController::TestCase
     assert_equal 1, QBWC.pending_jobs(COMPANY).count
   end
 
+  test "authenticate with initialization block" do
+     initializer_called = false
+     QBWC.set_session_initializer() do
+        initializer_called = true
+     end
+
+    _authenticate
+    assert initializer_called
+  end
+
   test "send_request" do
     _authenticate_with_queued_job
 

--- a/test/qbwc/controllers/controller_test.rb
+++ b/test/qbwc/controllers/controller_test.rb
@@ -76,7 +76,7 @@ class QBWCControllerTest < ActionController::TestCase
         initializer2_called = true
      end
 
-    _authenticate
+    _authenticate_with_queued_job
     assert ! initializer1_called
     assert   initializer2_called
   end

--- a/test/qbwc/controllers/controller_test.rb
+++ b/test/qbwc/controllers/controller_test.rb
@@ -15,6 +15,7 @@ class QBWCControllerTest < ActionController::TestCase
     #p @controller.view_paths
 
     QBWC.clear_jobs
+    QBWC.set_session_initializer() {|session| }
   end
 
   test "qwc" do
@@ -48,11 +49,18 @@ class QBWCControllerTest < ActionController::TestCase
 
   test "authenticate with initialization block" do
      initializer_called = false
-     QBWC.set_session_initializer() do
+     QBWC.set_session_initializer() do |session|
         initializer_called = true
+        assert_not_nil session
+        assert_equal QBWC_USERNAME, session.user
+        assert_equal 0, session.progress
+        assert_nil session.error
+        #assert_not_nil session.current_job
+        #assert_not_nil session.pending_jobs
+        #assert_equal 1, session.pending_jobs.count
      end
 
-    _authenticate
+    _authenticate_with_queued_job
     assert initializer_called
   end
 
@@ -60,11 +68,11 @@ class QBWCControllerTest < ActionController::TestCase
      initializer1_called = false
      initializer2_called = false
 
-     QBWC.set_session_initializer() do
+     QBWC.set_session_initializer() do |session|
         initializer1_called = true
      end
 
-     QBWC.set_session_initializer() do
+     QBWC.set_session_initializer() do |session|
         initializer2_called = true
      end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -45,6 +45,7 @@ module QbwcTestApplication
       c.username = QBWC_USERNAME
       c.password = QBWC_PASSWORD
       c.company_file_path = COMPANY
+      c.session_initializer = Proc.new{|| $CONFIG_SESSION_INITIALIZER_PROC_EXECUTED = true }
       c.logger = Logger.new('/dev/null') # or STDOUT
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -45,7 +45,7 @@ module QbwcTestApplication
       c.username = QBWC_USERNAME
       c.password = QBWC_PASSWORD
       c.company_file_path = COMPANY
-      c.session_initializer = Proc.new{|| $CONFIG_SESSION_INITIALIZER_PROC_EXECUTED = true }
+      c.session_initializer = Proc.new{|session| $CONFIG_SESSION_INITIALIZER_PROC_EXECUTED = true }
       c.logger = Logger.new('/dev/null') # or STDOUT
     end
   end


### PR DESCRIPTION
This creates new function `set_session_initializer` to perform arbitrary processing at the beginning of each QuickBooks Web Connector session.