### PR TITLE
Fix session progress when passing requests

### DIFF
--- a/lib/qbwc/session.rb
+++ b/lib/qbwc/session.rb
@@ -33,7 +33,7 @@ class QBWC::Session
       pending_jobs.shift
       reset(true) or break
     end
-    self.progress = 100 if request.nil?
+    self.progress = 100 if request.nil? && pending_jobs.empty?
     request
   end
   alias :next :next_request  # Deprecated method name 'next'

--- a/lib/qbwc/session.rb
+++ b/lib/qbwc/session.rb
@@ -16,6 +16,7 @@ class QBWC::Session
     @error = nil
     @progress = 0
     @iterator_id = nil
+    @initial_job_count = pending_jobs.length
 
     @ticket = ticket || Digest::SHA1.hexdigest("#{Rails.application.config.secret_token}#{Time.now.to_i}")
 
@@ -33,7 +34,8 @@ class QBWC::Session
       pending_jobs.shift
       reset(true) or break
     end
-    self.progress = 100 if request.nil? && pending_jobs.empty?
+    jobs_completed = @initial_job_count - pending_jobs.length
+    self.progress = ((jobs_completed.to_f  / @initial_job_count.to_f ) * 100).to_i
     request
   end
   alias :next :next_request  # Deprecated method name 'next'

--- a/test/qbwc/integration/session_test.rb
+++ b/test/qbwc/integration/session_test.rb
@@ -28,7 +28,7 @@ class SessionTest < ActionDispatch::IntegrationTest
     # Simulate controller 1st send_request and receive_response
     request = session.current_request
     session.response = QBWC_CUSTOMER_QUERY_RESPONSE_INFO
-    assert_equal 0, session.progress
+    assert_equal 50, session.progress
 
     # Simulate controller 2nd send_request and receive_response
     request = session.current_request
@@ -50,7 +50,7 @@ class SessionTest < ActionDispatch::IntegrationTest
     # Simulate controller 1st send_request and receive_response
     request = session.current_request
     session.response = QBWC_CUSTOMER_ADD_RESPONSE_LONG
-    assert_equal 0, session.progress
+    assert_equal 50, session.progress
 
     # Simulate controller 2nd send_request and receive_response
     request = session.current_request

--- a/test/qbwc/integration/session_test.rb
+++ b/test/qbwc/integration/session_test.rb
@@ -58,20 +58,10 @@ class SessionTest < ActionDispatch::IntegrationTest
     assert_equal 100, session.progress
   end
 
-  class SessionSpecRequestWorker < QBWC::Worker
-    def requests
-      {:name => 'bleech'}
-    end
-  end
-
-  test "sends request only once when providing a code block to add_job" do
-    COMPANY = ''
-    JOBNAME = 'add_joe_customer'
-
-    QBWC.api = :qb
+  test "sends request only once when passing requests to add_job" do
 
     # Add a job and pass a request
-    QBWC.add_job(JOBNAME, true, COMPANY, SessionSpecRequestWorker, QBWC_CUSTOMER_ADD_RQ_LONG)
+    QBWC.add_job(:add_joe_customer, true, COMPANY, QBWC::Worker, QBWC_CUSTOMER_ADD_RQ_LONG)
 
     assert_equal 1, QBWC.jobs.count
     assert_equal 1, QBWC.pending_jobs(COMPANY).count
@@ -100,17 +90,13 @@ class SessionTest < ActionDispatch::IntegrationTest
   end
 
   test "processes warning responses and deletes the job" do
-    company = ''
-    qbwc_username = 'myUserName'
-
-    QBWC.api = :qb
 
     # Add a job
-    QBWC.add_job(:query_joe_customer, true, company, QueryAndDeleteWorker)
+    QBWC.add_job(:query_joe_customer, true, COMPANY, QueryAndDeleteWorker)
 
     # Simulate controller receive_response
-    ticket_string = QBWC::ActiveRecord::Session.new(qbwc_username, company).ticket
-    session = QBWC::Session.new(nil, company)
+    ticket_string = QBWC::ActiveRecord::Session.new(QBWC_USERNAME, COMPANY).ticket
+    session = QBWC::Session.new(nil, COMPANY)
 
     session.response = QBWC_CUSTOMER_QUERY_RESPONSE_WARN
     assert_equal 100, session.progress
@@ -122,17 +108,13 @@ class SessionTest < ActionDispatch::IntegrationTest
   end
 
   test "processes error responses and deletes the job" do
-    company = ''
-    qbwc_username = 'myUserName'
-
-    QBWC.api = :qb
 
     # Add a job
-    QBWC.add_job(:query_joe_customer, true, company, QueryAndDeleteWorker)
+    QBWC.add_job(:query_joe_customer, true, COMPANY, QueryAndDeleteWorker)
 
     # Simulate controller receive_response
-    ticket_string = QBWC::ActiveRecord::Session.new(qbwc_username, company).ticket
-    session = QBWC::Session.new(nil, company)
+    ticket_string = QBWC::ActiveRecord::Session.new(QBWC_USERNAME, COMPANY).ticket
+    session = QBWC::Session.new(nil, COMPANY)
 
     session.response = QBWC_CUSTOMER_QUERY_RESPONSE_ERROR
     assert_equal 0, session.progress

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -120,6 +120,18 @@ QBWC_CUSTOMER_ADD_RQ_LONG = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r
 
 QBWC_CUSTOMER_ADD_RESPONSE_LONG = "<?xml version=\"1.0\" ?><QBXML><QBXMLMsgsRs><CustomerAddRs statusCode=\"0\" statusSeverity=\"Info\" statusMessage=\"Status OK\"><CustomerRet><ListID>8000001B-1405768916</ListID><TimeCreated>2014-07-19T07:21:56-05:00</TimeCreated><TimeModified>2014-07-19T07:21:56-05:00</TimeModified><EditSequence>1405768916</EditSequence><Name>mrjoecustomer</Name><FullName>Joseph Customer</FullName><IsActive>true</IsActive><Sublevel>0</Sublevel><CompanyName>Joes Garage</CompanyName><Salutation>Mr</Salutation><FirstName>Joe</FirstName><LastName>Customer</LastName><BillAddress><Addr1>123 Main St.</Addr1><City>Mountain View</City><State>CA</State><PostalCode>94566</PostalCode></BillAddress><Email>joecustomer@gmail.com</Email><Balance>0.00</Balance><TotalBalance>0.00</TotalBalance><AccountNumber>89087</AccountNumber><CreditLimit>2000.00</CreditLimit><JobStatus>None</JobStatus></CustomerRet></CustomerAddRs></QBXMLMsgsRs></QBXML>"
 
+QBWC_CUSTOMER_QUERY_RQ = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r
+    <?qbxml version=\"7.0\"?>\r
+    <QBXML>\r
+      <QBXMLMsgsRq onError = \"stopOnError\">\r
+        <CustomerQueryRq>\r
+          <FullName>#{QBWC_USERNAME}</FullName>\r
+        </CustomerQueryRq>\r
+      </QBXMLMsgsRq>\r
+    </QBXML>\r"
+
+QBWC_CUSTOMER_QUERY_RESPONSE_INFO = "<?xml version=\"1.0\" ?><QBXML><QBXMLMsgsRs><CustomerQueryRs statusCode=\"0\" statusSeverity=\"Info\" statusMessage=\"Status OK\"><CustomerRet><ListID>8000001B-1405777862</ListID><TimeCreated>2014-07-30T21:11:20-05:00</TimeCreated><TimeModified>2005-07-30T21:11:20-05:00</TimeModified><EditSequence>1405777862</EditSequence><Name>#{QBWC_USERNAME}</Name><Salutation>Mr</Salutation><FullName>#{QBWC_USERNAME}</FullName><IsActive>true</IsActive><Sublevel>0</Sublevel><Email>#{QBWC_USERNAME}@gmail.com</Email><Balance>0.00</Balance><TotalBalance>0.00</TotalBalance><AccountNumber>123456789</AccountNumber><JobStatus>None</JobStatus></CustomerRet></CustomerQueryRs></QBXMLMsgsRs></QBXML>"
+
 QBWC_CUSTOMER_QUERY_RESPONSE_WARN = "<?xml version=\"1.0\" ?><QBXML><QBXMLMsgsRs><CustomerQueryRs statusCode=\"500\" statusSeverity=\"Warn\" statusMessage=\"The query request has not been fully completed. There was a required element (&quot;bleech&quot;) that could not be found in QuickBooks.\" /></QBXMLMsgsRs></QBXML>"
 
 QBWC_CUSTOMER_QUERY_RESPONSE_ERROR = "<?xml version=\"1.0\" ?><QBXML><QBXMLMsgsRs><CustomerQueryRs statusCode=\"3120\" statusSeverity=\"Error\" statusMessage=\"Object &quot;8000001B-1405768916&quot; specified in the request cannot be found.  QuickBooks error message: Invalid argument.  The specified record does not exist in the list.\" /></QBXMLMsgsRs></QBXML>"


### PR DESCRIPTION
This primarily fixes an issue with session.progress not updating properly when passing requests into add_job. Two new test cases were added; one for passing requests, and one for worker requests.

As a bonus, this also contains these items that seemed convenient to address at the same time:
* Improve calculation of session.progress as a percentage of jobs completed
* DRY code maintenance of existing session tests
