### PR TITLE
Session progress during error conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Note: a QuickBooks Web Connector session is established when you manually run (u
 
 ## Handling errors ##
 
-By default, when an error response is received from QuickBooks, no further requests will be processed in the current job or in subsequent jobs. 
+By default, when an error response is received from QuickBooks, `QBWC::Worker#handle_response` will be invoked but no further requests will be processed in the current job or in subsequent jobs. 
 However, the job will remain persisted and so will be attempted again at next QuickBooks Web Connector session. Unless there is some intervention, presumably the job will fail again and block all remaining jobs and their requests from being serviced.
 
 To have qbwc continue with the next request after receiving an error, set `on_error` to `:continue` in `config/initializers/qbwc.rb`.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ QBWC.add_job(:list_customers, true, '', CustomerTestWorker)
 Your job will be persisted in your database and will remain active and run every time QuickBooks Web Connector runs an update. If you don't want this to happen, you can have have your job disable or delete itself after completion. For example:
 
 ```ruby
-	def handle_response(r, job, request, data)
+	def handle_response(r, session, job, request, data)
 		QBWC.delete_job(job)
 	end
 
@@ -93,7 +93,7 @@ A job is associated to a worker, which is an object descending from `QBWC::Worke
 
 - `requests(job)` - defines the request(s) that QuickBooks should process - returns a `Hash` or an `Array` of `Hash`es.
 - `should_run?(job)` - whether this job should run (e.g. you can have a job run only under certain circumstances) - returns `Boolean` and defaults to `true`.
-- `handle_response(response, job, request, data)` - defines what to do with the response from Quickbooks.
+- `handle_response(response, session, job, request, data)` - defines what to do with the response from Quickbooks.
 
 All three methods are not invoked until a QuickBooks Web Connector session has been established with your web service.
 
@@ -113,7 +113,7 @@ class CustomerTestWorker < QBWC::Worker
 		}
 	end
 
-	def handle_response(r, job, request, data)
+	def handle_response(r, session, job, request, data)
 		# handle_response will get customers in groups of 100. When this is 0, we're done.
 		complete = r['xml_attributes']['iteratorRemainingCount'] == '0'
 

--- a/README.md
+++ b/README.md
@@ -142,16 +142,6 @@ Similarly, a `QBWC::Worker#handle_response` method cannot access variables that 
 
 ## Sessions ##
 
-### Handling errors ###
-
-When any error response is received from QuickBooks Web Connector, by default the session will be halted and no further jobs or their requests requests will be processed. You can change this default behavior to continue processing jobs and their requests by assigning this in `config/initializers/qbwc.rb`:
-
-```ruby
-c.on_error = :continue
-```
-
-### Optional session initialization ###
-
 In certain cases, you may want to perform some initialization prior to each QuickBooks Web Connector session. For this purpose, you may optionally provide initialization code that will be invoked once when each QuickBooks Web Connector session is established, and prior to executing any queued jobs. This initialization code will not be invoked for any session in which no jobs are queued.
 
 You assign this initialization code either (a) during configuration, and/or (b) in application code by calling `set_session_initializer` (prior to any QuickBooks Web Connector session being established). For example:
@@ -180,6 +170,13 @@ In application code:
 Note: If you `set_session initializer` in your application code, you're only affecting the process that your application code runs in. A request to another process (e.g. if you're multiprocess or you restarted the server) means that QBWC won't see the session initializer.
 
 Note: a QuickBooks Web Connector session is established when you manually run (update) an application's web service in QuickBooks Web Connector, or when QuickBooks Web Connector automatically executes a scheduled update.
+
+## Handling errors ##
+
+By default, when an error response is received from QuickBooks, no further requests will be processed in the current job or in subsequent jobs. 
+However, the job will remain persisted and so will be attempted again at next QuickBooks Web Connector session. Unless there is some intervention, presumably the job will fail again and block all remaining jobs and their requests from being serviced.
+
+To have qbwc continue with the next request after receiving an error, set `on_error` to `:continue` in `config/initializers/qbwc.rb`.
 
 ## Contributing to qbwc
 

--- a/README.md
+++ b/README.md
@@ -173,8 +173,7 @@ Note: a QuickBooks Web Connector session is established when you manually run (u
 
 ## Handling errors ##
 
-By default, when an error response is received from QuickBooks, `QBWC::Worker#handle_response` will be invoked but no further requests will be processed in the current job or in subsequent jobs. 
-However, the job will remain persisted and so will be attempted again at next QuickBooks Web Connector session. Unless there is some intervention, presumably the job will fail again and block all remaining jobs and their requests from being serviced.
+By default, when an error response is received from QuickBooks, `QBWC::Worker#handle_response` will be invoked but no further requests will be processed in the current job or in subsequent jobs. However, the job will remain persisted and so will be attempted again at next QuickBooks Web Connector session. Unless there is some intervention, presumably the job will fail again and block all remaining jobs and their requests from being serviced.
 
 To have qbwc continue with the next request after receiving an error, set `on_error` to `:continue` in `config/initializers/qbwc.rb`.
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,16 @@ Similarly, a `QBWC::Worker#handle_response` method cannot access variables that 
 
 ## Sessions ##
 
+### Handling errors ###
+
+When any error response is received from QuickBooks Web Connector, by default the session will be halted and no further jobs or their requests requests will be processed. You can change this default behavior to continue processing jobs and their requests by assigning this in `config/initializers/qbwc.rb`:
+
+```ruby
+c.on_error = :continue
+```
+
+### Optional session initialization ###
+
 In certain cases, you may want to perform some initialization prior to each QuickBooks Web Connector session. For this purpose, you may optionally provide initialization code that will be invoked once when each QuickBooks Web Connector session is established, and prior to executing any queued jobs. This initialization code will not be invoked for any session in which no jobs are queued.
 
 You assign this initialization code either (a) during configuration, and/or (b) in application code by calling `set_session_initializer` (prior to any QuickBooks Web Connector session being established). For example:

--- a/lib/qbwc/job.rb
+++ b/lib/qbwc/job.rb
@@ -21,7 +21,7 @@ class QBWC::Job
     completed_request = requests[request_index]
     advance_next_request if advance
     QBWC.logger.info "Job '#{name}' received response: '#{response}'."
-    worker.handle_response(response, self, completed_request, data)
+    worker.handle_response(response, session, self, completed_request, data)
   end
 
   def advance_next_request

--- a/lib/qbwc/job.rb
+++ b/lib/qbwc/job.rb
@@ -17,6 +17,7 @@ class QBWC::Job
   end
 
   def process_response(response, session, advance)
+    QBWC.logger.info "Processing response."
     completed_request = requests[request_index]
     advance_next_request if advance
     QBWC.logger.info "Job '#{name}' received response: '#{response}'."

--- a/lib/qbwc/session.rb
+++ b/lib/qbwc/session.rb
@@ -29,7 +29,10 @@ class QBWC::Session
   end
 
   def next_request
-    return nil if current_job.nil?
+    if current_job.nil?
+      self.progress = 100
+      return nil
+    end
     until (request = current_job.next_request) do
       pending_jobs.shift
       reset(true) or break
@@ -59,7 +62,7 @@ class QBWC::Session
       QBWC.logger.info 'Parsing headers.'
       parse_response_header(response)
       QBWC.logger.info "Processing response."
-      self.current_job.process_response(response, self, iterator_id.blank?)
+      self.current_job.process_response(response, self, iterator_id.blank?) unless self.current_job.nil?
       self.next_request # search next request
 
     rescue => e

--- a/lib/qbwc/session.rb
+++ b/lib/qbwc/session.rb
@@ -58,10 +58,10 @@ class QBWC::Session
       response = response[response.keys.first]
       QBWC.logger.info 'Parsing headers.'
       parse_response_header(response)
-      is_error = (self.error && self.status_severity == 'Error')
       QBWC.logger.info "Processing response."
-      self.current_job.process_response(response, self, iterator_id.blank? && (!is_error || QBWC::on_error == 'continueOnError'))
-      self.next_request unless is_error || self.iterator_id.present? # search next request
+      self.current_job.process_response(response, self, iterator_id.blank?)
+      self.next_request # search next request
+
     rescue => e
       self.error = e.message
       QBWC.logger.warn "An error occured in QBWC::Session: #{e.message}"

--- a/lib/qbwc/session.rb
+++ b/lib/qbwc/session.rb
@@ -68,7 +68,7 @@ class QBWC::Session
       response = QBWC.parser.from_qbxml(qbxml_response)["qbxml"]["qbxml_msgs_rs"].except("xml_attributes")
       response = response[response.keys.first]
       parse_response_header(response)
-      self.current_job.process_response(response, self, iterator_id.blank?) unless self.current_job.nil? || error_and_stop_requested?
+      self.current_job.process_response(response, self, iterator_id.blank?) unless self.current_job.nil?
       self.next_request # search next request
 
     rescue => e

--- a/lib/qbwc/session.rb
+++ b/lib/qbwc/session.rb
@@ -67,7 +67,6 @@ class QBWC::Session
       QBWC.logger.info 'Parsing response.'
       response = QBWC.parser.from_qbxml(qbxml_response)["qbxml"]["qbxml_msgs_rs"].except("xml_attributes")
       response = response[response.keys.first]
-      QBWC.logger.info 'Parsing headers.'
       parse_response_header(response)
       self.current_job.process_response(response, self, iterator_id.blank?) unless self.current_job.nil? || error_and_stop_requested?
       self.next_request # search next request
@@ -104,6 +103,8 @@ class QBWC::Session
   end
 
   def parse_response_header(response)
+    QBWC.logger.info 'Parsing headers.'
+
     self.iterator_id = nil
     self.error = nil
     self.status_code = nil
@@ -119,10 +120,9 @@ class QBWC::Session
                                                'iteratorRemainingCount', 'iteratorID')
     QBWC.logger.info "Parsed headers. statusSeverity: '#{status_severity}'. statusCode: '#{@status_code}'"
 
-    errmsg = "QBWC #{@status_severity.upcase}: #{@status_code} - #{status_message}"
     if @status_severity == 'Error' || @status_severity == 'Warn'
-      @status_severity == 'Error' ? QBWC.logger.error(errmsg) : QBWC.logger.warn(errmsg)
-      self.error = errmsg
+      self.error = "QBWC #{@status_severity.upcase}: #{@status_code} - #{status_message}"
+      @status_severity == 'Error' ? QBWC.logger.error(self.error) : QBWC.logger.warn(self.error)
     end
 
     self.iterator_id = iterator_id if iterator_remaining_count.to_i > 0 && @status_severity != 'Error'

--- a/lib/qbwc/worker.rb
+++ b/lib/qbwc/worker.rb
@@ -9,7 +9,7 @@ module QBWC
       true
     end
 
-    def handle_response(response, job, request, data)
+    def handle_response(response, session, job, request, data)
     end
 
   end

--- a/test/qbwc/integration/job_management_test.rb
+++ b/test/qbwc/integration/job_management_test.rb
@@ -69,7 +69,7 @@ class JobManagementTest < ActionDispatch::IntegrationTest
       {:customer_query_rq => {:full_name => 'Quincy Bob William Carlos'}}
     end
 
-    def handle_response(resp, job, request, data)
+    def handle_response(resp, session, job, request, data)
       QBWC.delete_job(job.name)
     end
   end

--- a/test/qbwc/integration/request_generation_test.rb
+++ b/test/qbwc/integration/request_generation_test.rb
@@ -52,7 +52,7 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
         {:customer_query_rq => {:full_name => 'Quentin Billy Wyatt Charles'}}
       ]
     end
-    def handle_response(response, job, request, data)
+    def handle_response(response, session, job, request, data)
       $REQUESTS_FOUND_IN_RESPONSE = request
     end
   end
@@ -97,7 +97,7 @@ class RequestGenerationTest < ActionDispatch::IntegrationTest
       $REQUESTS_FROM_DB
     end
 
-    def handle_response(response, job, request, data)
+    def handle_response(response, session, job, request, data)
       $REQUESTS_FROM_DB.shift  # Simulate marking first request as completed
       job.reset
     end

--- a/test/qbwc/integration/response_test.rb
+++ b/test/qbwc/integration/response_test.rb
@@ -241,31 +241,27 @@ class ResponseTest < ActionDispatch::IntegrationTest
   end
 
   test "processes warning then error stop 2requests byworker" do
-    skip("Not correct yet")
     QBWC.on_error = :stop
     QBWC.add_job(:multiple_request_job, true, COMPANY, MultiRequestWorker)
-    _test_warning_then_error
+    _test_warning_then_error(0)
   end
 
   test "processes warning then error continue 2requests byworker" do
-    skip("Not correct yet")
     QBWC.on_error = :continue
     QBWC.add_job(:multiple_request_job, true, COMPANY, MultiRequestWorker)
-    _test_warning_then_error
+    _test_warning_then_error(0)
   end
 
   test "processes warning then error stop 2requests byargument" do
-    skip("Not correct yet")
     QBWC.on_error = :stop
     QBWC.add_job(:multiple_request_job, true, COMPANY, QBWC::Worker, [QBWC_CUSTOMER_QUERY_RQ, QBWC_CUSTOMER_QUERY_RQ])
-    _test_warning_then_error
+    _test_warning_then_error(0)
   end
 
   test "processes warning then error continue 2requests byargument" do
-    skip("Not correct yet")
     QBWC.on_error = :continue
     QBWC.add_job(:multiple_request_job, true, COMPANY, QBWC::Worker, [QBWC_CUSTOMER_QUERY_RQ, QBWC_CUSTOMER_QUERY_RQ])
-    _test_warning_then_error
+    _test_warning_then_error(0)
   end
 
   test "processes error then warning stop 2jobs" do
@@ -283,31 +279,27 @@ class ResponseTest < ActionDispatch::IntegrationTest
   end
 
   test "processes error then warning stop 2requests byworker" do
-    skip("Not correct yet")
     QBWC.on_error = :stop
     QBWC.add_job(:multiple_request_job, true, COMPANY, MultiRequestWorker)
     _test_error_then_warning_that_stops
   end
 
   test "processes error then warning continue 2requests byworker" do
-    skip("Not correct yet")
     QBWC.on_error = :continue
     QBWC.add_job(:multiple_request_job, true, COMPANY, MultiRequestWorker)
-    _test_error_then_warning
+    _test_error_then_warning(0)
   end
 
   test "processes error then warning stop 2requests byargument" do
-    skip("Not correct yet")
     QBWC.on_error = :stop
     QBWC.add_job(:multiple_request_job, true, COMPANY, QBWC::Worker, [QBWC_CUSTOMER_QUERY_RQ, QBWC_CUSTOMER_QUERY_RQ])
     _test_error_then_warning_that_stops
   end
 
   test "processes error then warning continue 2requests byargument" do
-    skip("Not correct yet")
     QBWC.on_error = :continue
     QBWC.add_job(:multiple_request_job, true, COMPANY, QBWC::Worker, [QBWC_CUSTOMER_QUERY_RQ, QBWC_CUSTOMER_QUERY_RQ])
-    _test_error_then_warning
+    _test_error_then_warning(0)
   end
 
 end

--- a/test/qbwc/integration/response_test.rb
+++ b/test/qbwc/integration/response_test.rb
@@ -93,7 +93,7 @@ class ResponseTest < ActionDispatch::IntegrationTest
 
     # Simulate controller receive_response
     session.response = QBWC_CUSTOMER_QUERY_RESPONSE_ERROR
-    assert_equal 0, session.progress
+    assert_equal 100, session.progress
     assert_equal '3120', session.status_code
     assert_equal 'Error', session.status_severity
     assert_equal "QBWC ERROR: 3120 - #{QBWC_CUSTOMER_QUERY_STATUS_MESSAGE_ERROR}", session.error
@@ -116,6 +116,7 @@ class ResponseTest < ActionDispatch::IntegrationTest
 
     # Simulate controller receive_response
     session.response = QBWC_CUSTOMER_QUERY_RESPONSE_WARN
+    assert_equal 50,     session.progress
     assert_equal '500',  session.status_code
     assert_equal 'Warn', session.status_severity
     assert_equal "QBWC WARN: 500 - #{QBWC_CUSTOMER_QUERY_STATUS_MESSAGE_WARN}", session.error
@@ -125,9 +126,12 @@ class ResponseTest < ActionDispatch::IntegrationTest
 
     # Simulate controller receive_response
     session.response = QBWC_CUSTOMER_QUERY_RESPONSE_ERROR
+    assert_equal 100,     session.progress
     assert_equal '3120',  session.status_code
     assert_equal 'Error', session.status_severity
     assert_equal "QBWC ERROR: 3120 - #{QBWC_CUSTOMER_QUERY_STATUS_MESSAGE_ERROR}", session.error
+
+    assert_nil session.next_request
   end
 
   test "processes error then warning" do
@@ -143,6 +147,7 @@ class ResponseTest < ActionDispatch::IntegrationTest
 
     # Simulate controller receive_response
     session.response = QBWC_CUSTOMER_QUERY_RESPONSE_ERROR
+    assert_equal 50,      session.progress
     assert_equal '3120',  session.status_code
     assert_equal 'Error', session.status_severity
     assert_equal "QBWC ERROR: 3120 - #{QBWC_CUSTOMER_QUERY_STATUS_MESSAGE_ERROR}", session.error
@@ -152,9 +157,12 @@ class ResponseTest < ActionDispatch::IntegrationTest
 
     # Simulate controller receive_response
     session.response = QBWC_CUSTOMER_QUERY_RESPONSE_WARN
+    assert_equal 100, session.progress
     assert_equal '500',  session.status_code
     assert_equal 'Warn', session.status_severity
     assert_equal "QBWC WARN: 500 - #{QBWC_CUSTOMER_QUERY_STATUS_MESSAGE_WARN}", session.error
+
+    assert_nil session.next_request
   end
 
 end

--- a/test/qbwc/integration/response_test.rb
+++ b/test/qbwc/integration/response_test.rb
@@ -77,7 +77,7 @@ class ResponseTest < ActionDispatch::IntegrationTest
     def requests(job)
       {:customer_query_rq => {:full_name => 'Quincy Bob William Carlos'}}
     end
-    def handle_response(response, job, request, data)
+    def handle_response(response, session, job, request, data)
       $HANDLE_RESPONSE_EXECUTED = true
       $HANDLE_RESPONSE_IS_PASSED_DATA = (data == $HANDLE_RESPONSE_DATA)
     end
@@ -103,7 +103,7 @@ class ResponseTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "handle_response must use splat operator when omitting job argument" do
+  test "handle_response must use splat operator when omitting remaining arguments" do
     QBWC.add_job(:integration_test, true, '', HandleResponseOmitsJobWorker)
     session = QBWC::Session.new('foo', '')
     assert_not_nil session.next_request
@@ -117,7 +117,7 @@ class ResponseTest < ActionDispatch::IntegrationTest
       {:name => 'mrjoecustomer'}
     end
 
-    def handle_response(resp, job, request, data)
+    def handle_response(resp, session, job, request, data)
        QBWC.delete_job(job.name)
     end
   end
@@ -199,7 +199,7 @@ class ResponseTest < ActionDispatch::IntegrationTest
         {:customer_query_rq => {:full_name => 'Second Request'}},
       ]
     end
-    def handle_response(resp, job, request, data)
+    def handle_response(resp, session, job, request, data)
       $HANDLE_RESPONSE_EXECUTED = true
     end
   end

--- a/test/qbwc/integration/response_test.rb
+++ b/test/qbwc/integration/response_test.rb
@@ -48,9 +48,9 @@ class ResponseTest < ActionDispatch::IntegrationTest
       if session.progress == 100
         assert_nil(session.next_request)
         return
-      else
-        assert_not_nil(session.next_request)
       end
+
+      assert_not_nil(session.next_request)
     end
 
   end


### PR DESCRIPTION
This expands testing of session progress when encountering errors and warns. This could stand a thorough review and exercise since it revises (but cleans up?) the flow of control when processing responses.

This is a branch of another branch feature/request_status_values.
