### PR TITLE
Handle alternate error format

### DIFF
--- a/lib/qbwc/controller.rb
+++ b/lib/qbwc/controller.rb
@@ -137,9 +137,9 @@ QWC
       if params[:hresult]
         QBWC.logger.warn "#{params[:hresult]}: #{params[:message]}"
         @session.error = params[:message]
-      else
-        @session.response = params[:response]
+        @session.status_code = params[:hresult]
       end
+      @session.response = params[:response]
       render :soap => {'tns:receiveResponseXMLResult' => (QBWC::on_error == 'continueOnError' || @session.error.nil?) ? @session.progress : -1}
     end
 

--- a/lib/qbwc/session.rb
+++ b/lib/qbwc/session.rb
@@ -65,9 +65,11 @@ class QBWC::Session
   def response=(qbxml_response)
     begin
       QBWC.logger.info 'Parsing response.'
-      response = QBWC.parser.from_qbxml(qbxml_response)["qbxml"]["qbxml_msgs_rs"].except("xml_attributes")
-      response = response[response.keys.first]
-      parse_response_header(response)
+      unless qbxml_response.nil?
+        response = QBWC.parser.from_qbxml(qbxml_response)["qbxml"]["qbxml_msgs_rs"].except("xml_attributes")
+        response = response[response.keys.first]
+        parse_response_header(response)
+      end
       self.current_job.process_response(response, self, iterator_id.blank?) unless self.current_job.nil?
       self.next_request # search next request
 

--- a/test/qbwc/controllers/controller_test.rb
+++ b/test/qbwc/controllers/controller_test.rb
@@ -86,16 +86,7 @@ class QBWCControllerTest < ActionController::TestCase
 
   test "send_request" do
     _authenticate_with_queued_job
-
-    ticket = QBWC::ActiveRecord::Session::QbwcSession.first.ticket
-    send_request_wash_out_soap_data = { :Envelope => { :Body => { SEND_REQUEST_SOAP_ACTION => SEND_REQUEST_PARAMS.update(:ticket => ticket) }}}
-
-    # send_request
-    @request.env["wash_out.soap_action"]  = SEND_REQUEST_SOAP_ACTION.to_s
-    @request.env["wash_out.soap_data"]    = send_request_wash_out_soap_data
-    @controller.env["wash_out.soap_data"] = @request.env["wash_out.soap_data"]
-
-    post 'send_request', use_route: :qbwc_action
+    _simulate_soap_request('send_request', SEND_REQUEST_SOAP_ACTION, SEND_REQUEST_PARAMS)
   end
 
   test "receive_response" do

--- a/test/qbwc/controllers/controller_test.rb
+++ b/test/qbwc/controllers/controller_test.rb
@@ -13,8 +13,12 @@ class QBWCControllerTest < ActionController::TestCase
     @controller.prepend_view_path("#{Gem::Specification.find_by_name("wash_out").gem_dir}/app/views")
     #p @controller.view_paths
 
+    QBWC.on_error = :stop
+    QBWC::ActiveRecord::Session::QbwcSession.all.each {|qbs| qbs.destroy}
     QBWC.clear_jobs
     QBWC.set_session_initializer() {|session| }
+
+    $HANDLE_RESPONSE_EXECUTED = false
   end
 
   test "qwc" do
@@ -92,6 +96,69 @@ class QBWCControllerTest < ActionController::TestCase
     @controller.env["wash_out.soap_data"] = @request.env["wash_out.soap_data"]
 
     post 'send_request', use_route: :qbwc_action
+  end
+
+  test "receive_response" do
+    _authenticate_with_queued_job
+    _simulate_soap_request('receive_response', RECEIVE_RESPONSE_SOAP_ACTION, RECEIVE_RESPONSE_PARAMS)
+
+    assert_match /tns:receiveResponseXMLResult.*100..tns:receiveResponseXMLResult/, @response.body
+  end
+
+  class CheckErrorValuesWorker < QBWC::Worker
+    def worker_assert_equal(expected_value, value, tag)
+      raise "#{tag} is not correct" if expected_value != value && ! expected_value.blank?
+    end
+
+    def requests(job)
+      {:customer_query_rq => {:full_name => 'Quincy Bob William Carlos'}}
+    end
+
+    def handle_response(response, session, job, request, expected)
+      unless expected.blank?
+        worker_assert_equal(expected[:session_error],           session.error,           "session.error")
+        worker_assert_equal(expected[:session_status_code],     session.status_code,     "session.status_code")
+        worker_assert_equal(expected[:session_status_severity], session.status_severity, "session.status_severity")
+      end
+      $HANDLE_RESPONSE_EXECUTED = true
+    end
+  end
+
+  def _receive_response_error_helper(receive_response_xml_result, schedule_second_job)
+    expected_values = {
+      :session_error           => RECEIVE_RESPONSE_ERROR_PARAMS[:message],
+      :session_status_code     => RECEIVE_RESPONSE_ERROR_PARAMS[:hresult],
+      :session_status_severity => nil,
+    }
+
+    QBWC.add_job(:customer_add_rq_job1, true, COMPANY, CheckErrorValuesWorker, nil, expected_values)
+    QBWC.add_job(:customer_add_rq_job2, true, COMPANY, CheckErrorValuesWorker) if schedule_second_job
+
+    _authenticate
+    _simulate_soap_request('receive_response', RECEIVE_RESPONSE_SOAP_ACTION, RECEIVE_RESPONSE_ERROR_PARAMS)
+
+    assert $HANDLE_RESPONSE_EXECUTED  # https://github.com/skryl/qbwc/pull/50#discussion_r23764154
+    assert_match /tns:receiveResponseXMLResult.*#{receive_response_xml_result}..tns:receiveResponseXMLResult/, @response.body
+  end
+
+  test "receive_response error stop" do
+    QBWC.on_error = :stop
+    _receive_response_error_helper(-1, false)
+  end
+
+  test "receive_response error continue" do
+    QBWC.on_error = :continue
+    _receive_response_error_helper(100, false)
+  end
+
+  test "receive_response error stop 2jobs" do
+    QBWC.on_error = :stop
+    _receive_response_error_helper(-1, true)
+  end
+
+  test "receive_response error continue 2jobs" do
+    QBWC.on_error = :continue
+    _receive_response_error_helper(50, true)
   end
 
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -166,6 +166,36 @@ SEND_REQUEST_PARAMS = {
 
 SEND_REQUEST_SOAP_ACTION = :sendRequestXML
 
+
+RECEIVE_RESPONSE_PARAMS = {
+  :ticket   => "60676ae302a35ead77c81b16993ef073ff3c930e",
+  :response => "<?xml version=\"1.0\" ?><QBXML><QBXMLMsgsRs><CustomerAddRs statusCode=\"0\" statusSeverity=\"Info\" statusMessage=\"Status OK\"><CustomerRet><ListID>8000007B-1420967073</ListID><TimeCreated>2015-02-03T07:49:33-05:00</TimeCreated><TimeModified>2015-02-03T07:49:33-05:00</TimeModified><EditSequence>1420967073</EditSequence><Name>mrjoecustomer</Name><FullName>Joseph Customer</FullName><IsActive>true</IsActive><Sublevel>0</Sublevel><Email>joecustomer@gmail.com</Email><Balance>0.00</Balance><TotalBalance>0.00</TotalBalance><AccountNumber>8</AccountNumber><JobStatus>None</JobStatus></CustomerRet></CustomerAddRs></QBXMLMsgsRs></QBXML>", 
+  :hresult => nil,
+  :message => nil}
+
+RECEIVE_RESPONSE_ERROR_PARAMS = {
+  :ticket   => "40fddf910fa903bde3caee77da7b30ab0bc90804",
+  :response => nil,
+  :hresult  => "0x80040400",
+  :message  => "QuickBooks found an error when parsing the provided XML text stream."
+}
+
+RECEIVE_RESPONSE_SOAP_ACTION = :receiveResponseXML
+
+#-------------------------------------------
+def _simulate_soap_request(http_action, soap_action, soap_params)
+
+  ticket = QBWC::ActiveRecord::Session::QbwcSession.first.ticket
+  wash_out_soap_data = { :Envelope => { :Body => { soap_action => soap_params.update(:ticket => ticket) }}}
+
+  # http://twobitlabs.com/2010/09/setting-request-headers-in-rails-functional-tests/
+  @request.env["wash_out.soap_action"]  = soap_action.to_s
+  @request.env["wash_out.soap_data"]    = wash_out_soap_data
+  @controller.env["wash_out.soap_data"] = @request.env["wash_out.soap_data"]
+
+  post http_action, use_route: :qbwc_action
+end
+
 #-------------------------------------------
 def _authenticate
   # http://twobitlabs.com/2010/09/setting-request-headers-in-rails-functional-tests/


### PR DESCRIPTION
Certain errors received from QuickBooks have an alternate format (blank response, hresult code, and error message, as shown in [this example](https://github.com/rchekaluk/qbwc/blob/bugfix/issue53/test/test_helper.rb#L176-181)).

When `on_error = :continue`, to prevent a looping condition where QuickBooks continues to issue `send_request` infinitely, the gem must return an appropriate progress value that eventually reaches 100 (a value of 100 informs QuickBooks that the session is finished).

This change passes these alternately-formatted errors into the gem's normal response processing, which subsequently triggers the normal calculation of progress value.

Fixes #53.