### PR TITLE
Assign status_severity for alternate-format errors

### DIFF
--- a/lib/qbwc/controller.rb
+++ b/lib/qbwc/controller.rb
@@ -138,6 +138,7 @@ QWC
         QBWC.logger.warn "#{params[:hresult]}: #{params[:message]}"
         @session.error = params[:message]
         @session.status_code = params[:hresult]
+        @session.status_severity = 'Error'
       end
       @session.response = params[:response]
       render :soap => {'tns:receiveResponseXMLResult' => (QBWC::on_error == 'continueOnError' || @session.error.nil?) ? @session.progress : -1}

--- a/test/qbwc/controllers/controller_test.rb
+++ b/test/qbwc/controllers/controller_test.rb
@@ -119,7 +119,7 @@ class QBWCControllerTest < ActionController::TestCase
     expected_values = {
       :session_error           => RECEIVE_RESPONSE_ERROR_PARAMS[:message],
       :session_status_code     => RECEIVE_RESPONSE_ERROR_PARAMS[:hresult],
-      :session_status_severity => nil,
+      :session_status_severity => 'Error',
     }
 
     QBWC.add_job(:customer_add_rq_job1, true, COMPANY, CheckErrorValuesWorker, nil, expected_values)


### PR DESCRIPTION
For completeness, this small adjustment to https://github.com/skryl/qbwc/pull/57 assigns `session.status_severity` to `'Error'` for alternate-format errors. Note that alternate-format errors don't contain a status_severity per se, so this assignment overloads the field with a placeholder value.

This change has only minor impacts:
* [`response_is_error?`](https://github.com/skryl/qbwc/blob/master/lib/qbwc/session.rb#L27-29
) is more accurate
* The application's `handle_response` will be able to access a proper value for `session.status_severity`
