### PR TITLE
Fix failing RoutesTest

### DIFF
--- a/test/qbwc/integration/routes_test.rb
+++ b/test/qbwc/integration/routes_test.rb
@@ -5,6 +5,15 @@ class RoutesTest < ActionDispatch::IntegrationTest
 
   def setup
     RoutesTest.app = Rails.application
+
+    # Initialize sets view paths
+    RoutesTest.app.initialize! unless RoutesTest.app.initialized?
+
+    # Assign routes
+    QbwcTestApplication::Application.routes.draw do
+      _assign_routes
+    end
+
     QBWC.clear_jobs
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,6 +35,7 @@ module QbwcTestApplication
   class Application < Rails::Application
     Rails.application.configure do
       config.secret_key_base = "stub"
+      config.eager_load = false
     end
     ActiveRecord::Base.establish_connection(:adapter => "sqlite3", :database => ":memory:")
     require '../qbwc/lib/generators/qbwc/install/templates/db/migrate/create_qbwc_jobs'
@@ -55,7 +56,7 @@ module QbwcTestApplication
 
 end
 
-QbwcTestApplication::Application.routes.draw do
+def _assign_routes
 
   # Manually stub these generated routes:
   #          GET        /qbwc/action(.:format)  qbwc#_generate_wsdl
@@ -73,6 +74,10 @@ QbwcTestApplication::Application.routes.draw do
 
   # Stub a root route
   root :to => "qbwc#qwc"
+end
+
+QbwcTestApplication::Application.routes.draw do
+  _assign_routes
 end
 
 class QbwcController < ActionController::Base


### PR DESCRIPTION
The failing `RoutesTest#test_qbwc/action_without_soap_returns_successfully` fails with `ActionView::MissingTemplate` exactly like #55, apparently due to an uninitialized Rails application environment. This pull request initializes the application in RoutesTest, thereby allowing the test to succeed.
