### PR TITLE
Allow suppressing sensitive log lines

### DIFF
--- a/lib/generators/qbwc/install/templates/config/qbwc.rb
+++ b/lib/generators/qbwc/install/templates/config/qbwc.rb
@@ -51,5 +51,5 @@ QBWC.configure do |c|
 
   # Some log lines contain sensitive information
   # (default false on production, true otherwise)
-  # c.log_sensitive_lines = false
+  # c.log_requests_and_responses = false
 end

--- a/lib/generators/qbwc/install/templates/config/qbwc.rb
+++ b/lib/generators/qbwc/install/templates/config/qbwc.rb
@@ -48,4 +48,8 @@ QBWC.configure do |c|
 
   # Logger to use.
   c.logger = Rails.logger
+
+  # Some log lines contain sensitive information
+  # (default false on production, true otherwise)
+  # c.log_sensitive_lines = false
 end

--- a/lib/qbwc.rb
+++ b/lib/qbwc.rb
@@ -63,8 +63,8 @@ module QBWC
   @@logger = Rails.logger
   
   # Some log lines contain sensitive information
-  mattr_accessor :log_sensitive_lines
-  @@log_sensitive_lines = Rails.env == 'production' ? false : true
+  mattr_accessor :log_requests_and_responses
+  @@log_requests_and_responses = Rails.env == 'production' ? false : true
 
   class << self
 

--- a/lib/qbwc.rb
+++ b/lib/qbwc.rb
@@ -62,6 +62,10 @@ module QBWC
   mattr_accessor :logger
   @@logger = Rails.logger
   
+  # Some log lines contain sensitive information
+  mattr_accessor :log_sensitive_lines
+  @@log_sensitive_lines = Rails.env == 'production' ? false : true
+
   class << self
 
     def storage_module

--- a/lib/qbwc/controller.rb
+++ b/lib/qbwc/controller.rb
@@ -127,9 +127,7 @@ QWC
     end
 
     def send_request
-      request = @session.current_request
-      request = request.try(:request) || ''
-      QBWC.logger.info("Current request is #{request}") if QBWC.log_sensitive_lines
+      request = @session.request_to_send
       render :soap => {'tns:sendRequestXMLResult' => request}
     end
 

--- a/lib/qbwc/controller.rb
+++ b/lib/qbwc/controller.rb
@@ -129,7 +129,7 @@ QWC
     def send_request
       request = @session.current_request
       request = request.try(:request) || ''
-      QBWC.logger.info("Current request is #{request}")
+      QBWC.logger.info("Current request is #{request}") if QBWC.log_sensitive_lines
       render :soap => {'tns:sendRequestXMLResult' => request}
     end
 

--- a/lib/qbwc/job.rb
+++ b/lib/qbwc/job.rb
@@ -20,7 +20,7 @@ class QBWC::Job
     QBWC.logger.info "Processing response."
     completed_request = requests[request_index]
     advance_next_request if advance
-    QBWC.logger.info "Job '#{name}' received response: '#{response}'."
+    QBWC.logger.info "Job '#{name}' received response: '#{response}'." if QBWC.log_sensitive_lines
     worker.handle_response(response, session, self, completed_request, data)
   end
 
@@ -92,12 +92,12 @@ class QBWC::Job
       self.requests = r
     end
 
-    QBWC.logger.info("Requests available are '#{requests}'.")
+    QBWC.logger.info("Requests available are '#{requests}'.") if QBWC.log_sensitive_lines
     ri = request_index
     QBWC.logger.info("Request index is '#{ri}'.")
     return nil if ri.nil? || requests.nil? || ri >= requests.length
     nr = requests[ri]
-    QBWC.logger.info("Next request is '#{nr}'.")
+    QBWC.logger.info("Next request is '#{nr}'.") if QBWC.log_sensitive_lines
     return QBWC::Request.new(nr)
   end
   alias :next :next_request  # Deprecated method name 'next'

--- a/lib/qbwc/job.rb
+++ b/lib/qbwc/job.rb
@@ -16,11 +16,11 @@ class QBWC::Job
     worker_class.constantize.new
   end
 
-  def process_response(response, session, advance)
+  def process_response(qbxml_response, response, session, advance)
     QBWC.logger.info "Processing response."
     completed_request = requests[request_index]
     advance_next_request if advance
-    QBWC.logger.info "Job '#{name}' received response: '#{response}'." if QBWC.log_sensitive_lines
+    QBWC.logger.info "Job '#{name}' received response: '#{qbxml_response}'." if QBWC.log_sensitive_lines
     worker.handle_response(response, session, self, completed_request, data)
   end
 

--- a/lib/qbwc/job.rb
+++ b/lib/qbwc/job.rb
@@ -20,7 +20,7 @@ class QBWC::Job
     QBWC.logger.info "Processing response."
     completed_request = requests[request_index]
     advance_next_request if advance
-    QBWC.logger.info "Job '#{name}' received response: '#{qbxml_response}'." if QBWC.log_sensitive_lines
+    QBWC.logger.info "Job '#{name}' received response: '#{qbxml_response}'." if QBWC.log_requests_and_responses
     worker.handle_response(response, session, self, completed_request, data)
   end
 
@@ -92,12 +92,12 @@ class QBWC::Job
       self.requests = r
     end
 
-    QBWC.logger.info("Requests available are '#{requests}'.") if QBWC.log_sensitive_lines
+    QBWC.logger.info("Requests available are '#{requests}'.") if QBWC.log_requests_and_responses
     ri = request_index
     QBWC.logger.info("Request index is '#{ri}'.")
     return nil if ri.nil? || requests.nil? || ri >= requests.length
     nr = requests[ri]
-    QBWC.logger.info("Next request is '#{nr}'.") if QBWC.log_sensitive_lines
+    QBWC.logger.info("Next request is '#{nr}'.") if QBWC.log_requests_and_responses
     return QBWC::Request.new(nr)
   end
   alias :next :next_request  # Deprecated method name 'next'

--- a/lib/qbwc/session.rb
+++ b/lib/qbwc/session.rb
@@ -78,7 +78,7 @@ class QBWC::Session
         response = response[response.keys.first]
         parse_response_header(response)
       end
-      self.current_job.process_response(response, self, iterator_id.blank?) unless self.current_job.nil?
+      self.current_job.process_response(qbxml_response, response, self, iterator_id.blank?) unless self.current_job.nil?
       self.next_request # search next request
 
     rescue => e

--- a/lib/qbwc/session.rb
+++ b/lib/qbwc/session.rb
@@ -65,7 +65,7 @@ class QBWC::Session
   def request_to_send
     request = current_request.try(:request) || ''
     QBWC.logger.info("Sending request from job #{current_job.name}")
-    QBWC.logger.info(request) if QBWC.log_sensitive_lines
+    QBWC.logger.info(request) if QBWC.log_requests_and_responses
 
     request
   end

--- a/lib/qbwc/session.rb
+++ b/lib/qbwc/session.rb
@@ -62,6 +62,14 @@ class QBWC::Session
     request
   end
 
+  def request_to_send
+    request = current_request.try(:request) || ''
+    QBWC.logger.info("Sending request from job #{current_job.name}")
+    QBWC.logger.info(request) if QBWC.log_sensitive_lines
+
+    request
+  end
+
   def response=(qbxml_response)
     begin
       QBWC.logger.info 'Parsing response.'

--- a/lib/qbwc/session.rb
+++ b/lib/qbwc/session.rb
@@ -63,8 +63,9 @@ class QBWC::Session
   end
 
   def request_to_send
+    current_job_name = current_job.name
     request = current_request.try(:request) || ''
-    QBWC.logger.info("Sending request from job #{current_job.name}")
+    QBWC.logger.info("Sending request from job #{current_job_name}")
     QBWC.logger.info(request) if QBWC.log_requests_and_responses
 
     request

--- a/test/qbwc/controllers/controller_test.rb
+++ b/test/qbwc/controllers/controller_test.rb
@@ -85,7 +85,8 @@ class QBWCControllerTest < ActionController::TestCase
   end
 
   test "send_request" do
-    _authenticate_with_queued_job
+    QBWC.add_job(:customer_add_rq_job, true, COMPANY, QBWC::Worker, QBWC_CUSTOMER_ADD_RQ)
+    _authenticate
     _simulate_soap_request('send_request', SEND_REQUEST_SOAP_ACTION, SEND_REQUEST_PARAMS)
   end
 

--- a/test/qbwc/integration/response_test.rb
+++ b/test/qbwc/integration/response_test.rb
@@ -89,7 +89,7 @@ class ResponseTest < ActionDispatch::IntegrationTest
     QBWC.add_job(:integration_test, true, '', HandleResponseWithDataWorker, nil, $HANDLE_RESPONSE_DATA)
     session = QBWC::Session.new('foo', '')
     assert_not_nil session.next_request
-    simulate_response(session)
+    simulate_response(session, QBWC_CUSTOMER_ADD_RESPONSE_LONG)
     assert_nil session.next_request
     assert $HANDLE_RESPONSE_IS_PASSED_DATA
   end

--- a/test/qbwc/integration/session_test.rb
+++ b/test/qbwc/integration/session_test.rb
@@ -79,4 +79,16 @@ class SessionTest < ActionDispatch::IntegrationTest
     assert_equal 100, session.progress
   end
 
+  test "request_to_send when no requests" do
+
+    QBWC.add_job(:add_joe_customer, true, COMPANY, QBWC::Worker, [])
+
+    assert_equal 1, QBWC.jobs.count
+    assert_equal 1, QBWC.pending_jobs(COMPANY).count
+
+    # Simulate controller send_request
+    session = QBWC::Session.new(nil, COMPANY)
+    request = session.request_to_send
+  end
+
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -85,6 +85,13 @@ class QbwcController < ActionController::Base
   include QBWC::Controller
 end
 
+QBWC_EMPTY_RESPONSE = "<?xml version=\"1.0\"?>\r
+    <?qbxml version=\"7.0\"?>\r
+    <QBXML>\r
+      <QBXMLMsgsRs onError=\"stopOnError\">\r
+      </QBXMLMsgsRs>\r
+    </QBXML>\r"
+
 QBWC_CUSTOMER_ADD_RQ = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r
     <?qbxml version=\"7.0\"?>\r
     <QBXML>\r
@@ -231,12 +238,7 @@ def _authenticate_wrong_password
   post 'authenticate', use_route: :qbwc_action
 end
 
-def simulate_response(session)
-  session.response = <<-EOF
-  <?xml version="1.0"?><?qbxml version="7.0"?>
-<QBXML>
-  <QBXMLMsgsRs onError="stopOnError">
-  </QBXMLMsgsRs>
-</QBXML>
-  EOF
+#-------------------------------------------
+def simulate_response(session, response=QBWC_EMPTY_RESPONSE)
+  session.response = response
 end


### PR DESCRIPTION
Adds new config parameter log_sensitive_lines (default `false` on production, and `true` otherwise) that determines if request and response content is logged.

Emits a log entry at each send_request operation that doesn't contain sensitive information (requires minor code restructuring).

Standardizes the format (string qbXML or hash) of logged requests and responses in this way:
* Internal requests: logged in the format in which they were provided (either string or hash)
* Requests sent to QuickBooks: logged as string qbXML
* Responses from QuickBooks: logged as string qbXML (this required a minor change)
