### PR TITLE
Fix issue 58

### DIFF
--- a/lib/qbwc/session.rb
+++ b/lib/qbwc/session.rb
@@ -106,6 +106,7 @@ class QBWC::Session
   def reset(reset_job = false)
     self.current_job = pending_jobs.first
     self.current_job.reset if reset_job && self.current_job
+    return self.current_job
   end
 
   def pending_jobs


### PR DESCRIPTION
Fixes #58 by explicitly returning a value from session.reset.

I've also struggled with the flow of control in session.next_request; I'd spent a little time trying to clean it up but gave up in the interest of time (though IIRC, the minor improvement https://github.com/skryl/qbwc/commit/3fb48dafb145b2b5e58781949df8813363bfb1b8 fell out of that inquiry).

I concur about implicit returns; even though they are appealing to the functional programming purist, I typically try to explicitly `return` whenever possible.
